### PR TITLE
fix: support global config file name `[.]aqua.y[a]ml`

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/suzuki-shunsuke/go-findconfig/findconfig"
@@ -88,12 +89,23 @@ func (ctrl *Controller) readConfig(configFilePath string, cfg *Config) error {
 
 type ConfigFinder interface {
 	Find(wd string) string
+	FindGlobal(rootDir string) string
 }
 
 type configFinder struct{}
 
 func (finder *configFinder) Find(wd string) string {
 	return findconfig.Find(wd, findconfig.Exist, "aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml")
+}
+
+func (finder *configFinder) FindGlobal(rootDir string) string {
+	for _, file := range []string{"aqua.yaml", "aqua.yml", ".aqua.yaml", ".aqua.yml"} {
+		cfgFilePath := filepath.Join(rootDir, "global", file)
+		if _, err := os.Stat(cfgFilePath); err == nil {
+			return cfgFilePath
+		}
+	}
+	return ""
 }
 
 type ConfigReader interface {

--- a/pkg/controller/exec.go
+++ b/pkg/controller/exec.go
@@ -51,7 +51,7 @@ func (ctrl *Controller) Exec(ctx context.Context, param *Param, args []string) e
 
 		pkg, pkgInfo, file = ctrl.findExecFile(inlineRegistry, cfg, exeName)
 		if pkg == nil {
-			cfgFilePath = filepath.Join(ctrl.RootDir, "global", "aqua.yaml")
+			cfgFilePath = ctrl.ConfigFinder.FindGlobal(ctrl.RootDir)
 			if _, err := os.Stat(cfgFilePath); err != nil {
 				return errCommandIsNotFound
 			}
@@ -71,7 +71,7 @@ func (ctrl *Controller) Exec(ctx context.Context, param *Param, args []string) e
 			}
 		}
 	} else {
-		cfgFilePath = filepath.Join(ctrl.RootDir, "global", "aqua.yaml")
+		cfgFilePath = ctrl.ConfigFinder.FindGlobal(ctrl.RootDir)
 		if _, err := os.Stat(cfgFilePath); err != nil {
 			return errCommandIsNotFound
 		}


### PR DESCRIPTION
Follow up #93