### PR TITLE
feat: add "program": "aqua" to log

### DIFF
--- a/cmd/aqua/main.go
+++ b/cmd/aqua/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/aqua/pkg/cli"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 )
 
 var (
@@ -25,12 +25,10 @@ func main() {
 		var hasExitCode HasExitCode
 		if errors.As(err, &hasExitCode) {
 			code := hasExitCode.ExitCode()
-			logrus.WithError(err).WithFields(logrus.Fields{
-				"exit_code": code,
-			}).Debug("command failed")
+			log.New().WithField("exit_code", code).Debug("command failed")
 			os.Exit(code)
 		}
-		logrus.Fatal(err)
+		log.New().Fatal(err)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/google/go-github/v38/github"
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
 	"golang.org/x/oauth2"
 )
@@ -28,13 +29,13 @@ func New(ctx context.Context, param *Param) (*Controller, error) {
 	if param.LogLevel != "" {
 		lvl, err := logrus.ParseLevel(param.LogLevel)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{
+			log.New().WithFields(logrus.Fields{
 				"log_level": param.LogLevel,
 			}).WithError(err).Error("the log level is invalid")
 		}
 		logrus.SetLevel(lvl)
 	}
-	logrus.WithFields(logrus.Fields{
+	log.New().WithFields(logrus.Fields{
 		"log_level": param.LogLevel,
 		"config":    param.ConfigFilePath,
 	}).Debug("CLI args")

--- a/pkg/controller/download.go
+++ b/pkg/controller/download.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 )
 
 func (ctrl *Controller) download(ctx context.Context, pkg *Package, pkgInfo *PackageInfo, dest, assetName string) error {
-	logE := logrus.WithFields(logrus.Fields{
+	logE := log.New().WithFields(logrus.Fields{
 		"package_name":    pkg.Name,
 		"package_version": pkg.Version,
 		"registry":        pkg.Registry,

--- a/pkg/controller/exec.go
+++ b/pkg/controller/exec.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 	"github.com/suzuki-shunsuke/go-error-with-exit-code/ecerror"
 	"github.com/suzuki-shunsuke/go-timeout/timeout"
 )
@@ -127,7 +127,7 @@ func (ctrl *Controller) findExecFile(inlineRegistry map[string]*PackageInfo, cfg
 	for _, pkg := range cfg.Packages {
 		pkgInfo, ok := inlineRegistry[pkg.Name]
 		if !ok {
-			logrus.Warnf("registry isn't found %s", pkg.Name)
+			log.New().Warnf("registry isn't found %s", pkg.Name)
 			continue
 		}
 		for _, file := range pkgInfo.Files {

--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 )
 
 func (ctrl *Controller) Install(ctx context.Context, param *Param) error { //nolint:cyclop,funlen
@@ -62,7 +63,7 @@ func (ctrl *Controller) Install(ctx context.Context, param *Param) error { //nol
 			maxInstallChan <- struct{}{}
 			if err := ctrl.installPackage(ctx, inlineRegistry, pkg, binDir, param.OnlyLink); err != nil {
 				<-maxInstallChan
-				logrus.WithFields(logrus.Fields{
+				log.New().WithFields(logrus.Fields{
 					"package_name": pkg.Name,
 				}).WithError(err).Error("install the package")
 				flagMutex.Lock()
@@ -91,7 +92,7 @@ func getMaxParallelism() int {
 	}
 	num, err := strconv.Atoi(envMaxParallelism)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
+		log.New().WithFields(logrus.Fields{
 			"AQUA_MAX_PARALLELISM": envMaxParallelism,
 		}).Warn("the environment variable AQUA_MAX_PARALLELISM must be a number")
 		return defaultMaxParallelism
@@ -103,7 +104,7 @@ func getMaxParallelism() int {
 }
 
 func (ctrl *Controller) installPackage(ctx context.Context, inlineRegistry map[string]*PackageInfo, pkg *Package, binDir string, onlyLink bool) error { //nolint:cyclop
-	logE := logrus.WithFields(logrus.Fields{
+	logE := log.New().WithFields(logrus.Fields{
 		"package_name":    pkg.Name,
 		"package_version": pkg.Version,
 		"registry":        pkg.Registry,
@@ -160,7 +161,7 @@ func warnFileSrc(pkg *Package, pkgInfo *PackageInfo, pkgPath string, file *File)
 	if file.Src.Empty() {
 		return
 	}
-	logE := logrus.WithFields(logrus.Fields{
+	logE := log.New().WithFields(logrus.Fields{
 		"file_name": file.Name,
 	})
 	fileSrc, err := file.RenderSrc(pkg, pkgInfo)
@@ -208,7 +209,7 @@ func (ctrl *Controller) createLink(binDir string, file *File) error {
 			return fmt.Errorf("unexpected file mode %s: %s", linkPath, mode.String())
 		}
 	}
-	logrus.WithFields(logrus.Fields{
+	log.New().WithFields(logrus.Fields{
 		"link_file": linkPath,
 		"new":       linkDest,
 	}).Info("create a symbolic link")
@@ -227,7 +228,7 @@ func (ctrl *Controller) recreateLink(linkPath, linkDest string) error {
 		return nil
 	}
 	// recreate link
-	logrus.WithFields(logrus.Fields{
+	log.New().WithFields(logrus.Fields{
 		"link_file": linkPath,
 		"old":       lnDest,
 		"new":       linkDest,

--- a/pkg/controller/install_proxy.go
+++ b/pkg/controller/install_proxy.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 )
 
 func (ctrl *Controller) installProxy(ctx context.Context) error {
@@ -16,7 +17,7 @@ func (ctrl *Controller) installProxy(ctx context.Context) error {
 		Version:  "v0.1.0", // renovate: depName=suzuki-shunsuke/aqua-proxy
 		Registry: "inline",
 	}
-	logE := logrus.WithFields(logrus.Fields{
+	logE := log.New().WithFields(logrus.Fields{
 		"package_name":    pkg.Name,
 		"package_version": pkg.Version,
 		"registry":        pkg.Registry,

--- a/pkg/controller/unarchive.go
+++ b/pkg/controller/unarchive.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
 )
 
 func getUnarchiver(filename, typ string) (interface{}, error) {
@@ -19,7 +20,7 @@ func getUnarchiver(filename, typ string) (interface{}, error) {
 
 func unarchive(body io.Reader, filename, typ, dest string) error { //nolint:cyclop
 	if isUnarchived(typ, filename) {
-		logrus.Debug("archive type is raw")
+		log.New().Debug("archive type is raw")
 		if err := os.MkdirAll(dest, 0o775); err != nil { //nolint:gomnd
 			return fmt.Errorf("create a directory (%s): %w", dest, err)
 		}
@@ -35,7 +36,7 @@ func unarchive(body io.Reader, filename, typ, dest string) error { //nolint:cycl
 	}
 	arc, err := getUnarchiver(filename, typ)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
+		log.New().WithFields(logrus.Fields{
 			"archive_type":           typ,
 			"filename":               filename,
 			"filepath.Ext(filename)": filepath.Ext(filename),

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,9 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+func New() *logrus.Entry {
+	return logrus.WithField("program", "aqua")
+}


### PR DESCRIPTION
aqua is called transparently.
Add `"program": "aqua"` to log of aqua for users to find that the source of log is `aqua`.

e.g.

```console
$ fzf --version
INFO[0000] create a symbolic link                        link_file=/workspace/.aqua/bin/fzf new=/root/.aqua/bin/aqua-proxy program=aqua
0.27.2 (e086f0b)
```