### PR TITLE
fix: handle SIGTERM

### DIFF
--- a/cmd/aqua/main.go
+++ b/cmd/aqua/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/suzuki-shunsuke/aqua/pkg/cli"
 	"github.com/suzuki-shunsuke/aqua/pkg/log"
@@ -43,7 +44,7 @@ func core() error {
 			Date:    date,
 		},
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return runner.Run(ctx, os.Args...) //nolint:wrapcheck
 }


### PR DESCRIPTION
Same as https://github.com/suzuki-shunsuke/aqua-proxy/pull/7

Note that this fix doesn't work for Windows.

https://pkg.go.dev/os#Signal

> The only signal values guaranteed to be present in the os package on all systems are os.Interrupt (send the process an interrupt) and os.Kill (force the process to exit).
> On Windows, sending os.Interrupt to a process with os.Process.Signal is not implemented;
> it will return an error instead of sending a signal.