### PR TITLE
feat: support HTTP

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,16 +32,20 @@ If the confgiuration file path isn't specified, the file named `[.]aqua.y[a]ml` 
 PackageInfo is the package metadata how the package is installed.
 
 * `name`: the package name
-* `type`: the package type. Only `github_release` is supported
+* `type`: the package type. Either `github_release` or `http` is supported
 * `archive_type`: the archive type (e.g. `zip`, `tar.gz`). Basically you don't have to specify this field because `aqua` understand the archive type from the filename extension.
   If the `archive_type` is `raw` or the filename has no extension, `aqua` treats the file isn't archived and uncompressed.
 * `files`: The list of files which the archive includes
 
-`github_release` has the following fields.
+The type `github_release` has the following fields.
 
 * `repo_owner`: GitHub Repository owner
 * `repo_name`: GitHub Repository name
 * `asset`: (type: `template string`) GitHub Release asset name
+
+The type `http` has the following fields.
+
+* `url`: Downloaded URL
 
 ### Registry
 
@@ -58,11 +62,12 @@ Only `inline` registry is supported.
 Some fields are parsed with [Go's text/template](https://pkg.go.dev/text/template) and [sprig](http://masterminds.github.io/sprig/).
 
 * `PackageInfo.asset`
+* `PackageInfo.url`
 * `File.src`
 
 The following variables are passed to the template.
 
-`PackageInfo.asset`
+`PackageInfo.url`, `PackageInfo.asset`
 
 * `Package`: the Package
   * `Name`

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +12,12 @@ import (
 	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
 	"gopkg.in/yaml.v2"
 )
+
+type Package struct {
+	Name     string `validate:"required"`
+	Registry string `validate:"required"`
+	Version  string `validate:"required"`
+}
 
 type Config struct {
 	Packages       []*Package   `validate:"dive"`
@@ -33,37 +38,14 @@ func (pkgInfos *PackageInfos) UnmarshalYAML(unmarshal func(interface{}) error) e
 	}
 	list := make([]PackageInfo, len(arr))
 	for i, p := range arr {
-		switch p.Type {
-		case pkgInfoTypeGitHubRelease:
-			pkgInfo := &GitHubReleasePackageInfo{
-				Name:        p.Name,
-				RepoOwner:   p.RepoOwner,
-				RepoName:    p.RepoName,
-				Asset:       p.Asset,
-				ArchiveType: p.ArchiveType,
-				Files:       p.Files,
-			}
-			list[i] = pkgInfo
-		case pkgInfoTypeHTTP:
-			pkgInfo := &HTTPPackageInfo{
-				Name:        p.Name,
-				ArchiveType: p.ArchiveType,
-				URL:         p.URL,
-				Files:       p.Files,
-			}
-			list[i] = pkgInfo
-		default:
-			return errors.New("type is invalid")
+		pkgInfo, err := p.GetPackageInfo()
+		if err != nil {
+			return err
 		}
+		list[i] = pkgInfo
 	}
 	*pkgInfos = list
 	return nil
-}
-
-type Package struct {
-	Name     string `validate:"required"`
-	Registry string `validate:"required"`
-	Version  string `validate:"required"`
 }
 
 type PackageInfo interface {
@@ -87,149 +69,27 @@ type mergedPackageInfo struct {
 	URL         *text.Template
 }
 
-type GitHubReleasePackageInfo struct {
-	Name        string  `validate:"required"`
-	ArchiveType string  `yaml:"archive_type"`
-	Files       []*File `validate:"required,dive"`
-
-	RepoOwner string         `yaml:"repo_owner" validate:"required"`
-	RepoName  string         `yaml:"repo_name" validate:"required"`
-	Asset     *text.Template `validate:"required"`
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetName() string {
-	return pkgInfo.Name
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetType() string {
-	return pkgInfoTypeGitHubRelease
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
-	return pkgInfo.ArchiveType
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
-	assetName, err := pkgInfo.RenderAsset(pkg)
-	if err != nil {
-		return "", fmt.Errorf("render the asset name: %w", err)
+func (pkgInfo *mergedPackageInfo) GetPackageInfo() (PackageInfo, error) {
+	switch pkgInfo.Type {
+	case pkgInfoTypeGitHubRelease:
+		return &GitHubReleasePackageInfo{
+			Name:        pkgInfo.Name,
+			RepoOwner:   pkgInfo.RepoOwner,
+			RepoName:    pkgInfo.RepoName,
+			Asset:       pkgInfo.Asset,
+			ArchiveType: pkgInfo.ArchiveType,
+			Files:       pkgInfo.Files,
+		}, nil
+	case pkgInfoTypeHTTP:
+		return &HTTPPackageInfo{
+			Name:        pkgInfo.Name,
+			ArchiveType: pkgInfo.ArchiveType,
+			URL:         pkgInfo.URL,
+			Files:       pkgInfo.Files,
+		}, nil
+	default:
+		return nil, errors.New("type is invalid")
 	}
-	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetFiles() []*File {
-	return pkgInfo.Files
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
-	assetName, err := pkgInfo.RenderAsset(pkg)
-	if err != nil {
-		return "", fmt.Errorf("render the asset name: %w", err)
-	}
-	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
-		return assetName, nil
-	}
-	if file.Src == nil {
-		return file.Name, nil
-	}
-	src, err := file.RenderSrc(pkg, pkgInfo)
-	if err != nil {
-		return "", fmt.Errorf("render the template file.src: %w", err)
-	}
-	return src, nil
-}
-
-func (pkgInfo *GitHubReleasePackageInfo) RenderAsset(pkg *Package) (string, error) {
-	return pkgInfo.Asset.Execute(map[string]interface{}{ //nolint:wrapcheck
-		"Package":     pkg,
-		"PackageInfo": pkgInfo,
-		"OS":          runtime.GOOS,
-		"Arch":        runtime.GOARCH,
-	})
-}
-
-type HTTPPackageInfo struct {
-	Name        string  `validate:"required"`
-	ArchiveType string  `yaml:"archive_type"`
-	Files       []*File `validate:"required,dive"`
-
-	URL *text.Template `validate:"required"`
-}
-
-func (pkgInfo *HTTPPackageInfo) GetName() string {
-	return pkgInfo.Name
-}
-
-func (pkgInfo *HTTPPackageInfo) GetType() string {
-	return pkgInfoTypeHTTP
-}
-
-func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
-	return pkgInfo.ArchiveType
-}
-
-func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
-	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
-		"Package":     pkg,
-		"PackageInfo": pkgInfo,
-		"OS":          runtime.GOOS,
-		"Arch":        runtime.GOARCH,
-	})
-	if err != nil {
-		return "", fmt.Errorf("render URL: %w", err)
-	}
-	u, err := url.Parse(uS) // TODO
-	if err != nil {
-		return "", fmt.Errorf("parse the URL: %w", err)
-	}
-	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), u.Host, u.Path), nil
-}
-
-func (pkgInfo *HTTPPackageInfo) GetFiles() []*File {
-	return pkgInfo.Files
-}
-
-func (pkgInfo *HTTPPackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
-	assetName, err := pkgInfo.RenderAsset(pkg)
-	if err != nil {
-		return "", fmt.Errorf("render the asset name: %w", err)
-	}
-	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
-		return assetName, nil
-	}
-	if file.Src == nil {
-		return file.Name, nil
-	}
-	src, err := file.RenderSrc(pkg, pkgInfo)
-	if err != nil {
-		return "", fmt.Errorf("render the template file.src: %w", err)
-	}
-	return src, nil
-}
-
-func (pkgInfo *HTTPPackageInfo) RenderURL(pkg *Package) (string, error) {
-	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
-		"Package":     pkg,
-		"PackageInfo": pkgInfo,
-		"OS":          runtime.GOOS,
-		"Arch":        runtime.GOARCH,
-	})
-	if err != nil {
-		return "", fmt.Errorf("render URL: %w", err)
-	}
-	return uS, nil
-}
-
-func (pkgInfo *HTTPPackageInfo) RenderAsset(pkg *Package) (string, error) {
-	uS, err := pkgInfo.RenderURL(pkg)
-	if err != nil {
-		return "", fmt.Errorf("render URL: %w", err)
-	}
-	u, err := url.Parse(uS) // TODO
-	if err != nil {
-		return "", fmt.Errorf("parse the URL: %w", err)
-	}
-	return filepath.Base(u.Path), nil
 }
 
 type File struct {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,8 +15,49 @@ import (
 )
 
 type Config struct {
-	Packages       []*Package     `validate:"dive"`
-	InlineRegistry []*PackageInfo `yaml:"inline_registry" validate:"dive"`
+	Packages       []*Package   `validate:"dive"`
+	InlineRegistry PackageInfos `yaml:"inline_registry" validate:"dive"`
+}
+
+type PackageInfos []PackageInfo
+
+const (
+	pkgInfoTypeGitHubRelease = "github_release"
+	pkgInfoTypeHTTP          = "http"
+)
+
+func (pkgInfos *PackageInfos) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var arr []mergedPackageInfo
+	if err := unmarshal(&arr); err != nil {
+		return err
+	}
+	list := make([]PackageInfo, len(arr))
+	for i, p := range arr {
+		switch p.Type {
+		case pkgInfoTypeGitHubRelease:
+			pkgInfo := &GitHubReleasePackageInfo{
+				Name:        p.Name,
+				RepoOwner:   p.RepoOwner,
+				RepoName:    p.RepoName,
+				Asset:       p.Asset,
+				ArchiveType: p.ArchiveType,
+				Files:       p.Files,
+			}
+			list[i] = pkgInfo
+		case pkgInfoTypeHTTP:
+			pkgInfo := &HTTPPackageInfo{
+				Name:        p.Name,
+				ArchiveType: p.ArchiveType,
+				URL:         p.URL,
+				Files:       p.Files,
+			}
+			list[i] = pkgInfo
+		default:
+			return errors.New("type is invalid")
+		}
+	}
+	*pkgInfos = list
+	return nil
 }
 
 type Package struct {
@@ -24,17 +66,80 @@ type Package struct {
 	Version  string `validate:"required"`
 }
 
-type PackageInfo struct {
-	Name        string         `validate:"required"`
-	Type        string         `validate:"required"`
-	RepoOwner   string         `yaml:"repo_owner" validate:"required"`
-	RepoName    string         `yaml:"repo_name" validate:"required"`
-	Asset       *text.Template `validate:"required"`
-	ArchiveType string         `yaml:"archive_type"`
-	Files       []*File        `validate:"required,dive"`
+type PackageInfo interface {
+	GetName() string
+	GetType() string
+	GetArchiveType() string
+	GetFiles() []*File
+	GetFileSrc(pkg *Package, file *File) (string, error)
+	GetPkgPath(rootDir string, pkg *Package) (string, error)
+	RenderAsset(pkg *Package) (string, error)
 }
 
-func (pkgInfo *PackageInfo) RenderAsset(pkg *Package) (string, error) {
+type mergedPackageInfo struct {
+	Name        string
+	Type        string
+	RepoOwner   string `yaml:"repo_owner"`
+	RepoName    string `yaml:"repo_name"`
+	Asset       *text.Template
+	ArchiveType string `yaml:"archive_type"`
+	Files       []*File
+	URL         *text.Template
+}
+
+type GitHubReleasePackageInfo struct {
+	Name        string  `validate:"required"`
+	ArchiveType string  `yaml:"archive_type"`
+	Files       []*File `validate:"required,dive"`
+
+	RepoOwner string         `yaml:"repo_owner" validate:"required"`
+	RepoName  string         `yaml:"repo_name" validate:"required"`
+	Asset     *text.Template `validate:"required"`
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetName() string {
+	return pkgInfo.Name
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetType() string {
+	return pkgInfoTypeGitHubRelease
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
+	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetFiles() []*File {
+	return pkgInfo.Files
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+		return assetName, nil
+	}
+	if file.Src == nil {
+		return file.Name, nil
+	}
+	src, err := file.RenderSrc(pkg, pkgInfo)
+	if err != nil {
+		return "", fmt.Errorf("render the template file.src: %w", err)
+	}
+	return src, nil
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) RenderAsset(pkg *Package) (string, error) {
 	return pkgInfo.Asset.Execute(map[string]interface{}{ //nolint:wrapcheck
 		"Package":     pkg,
 		"PackageInfo": pkgInfo,
@@ -43,12 +148,96 @@ func (pkgInfo *PackageInfo) RenderAsset(pkg *Package) (string, error) {
 	})
 }
 
+type HTTPPackageInfo struct {
+	Name        string  `validate:"required"`
+	ArchiveType string  `yaml:"archive_type"`
+	Files       []*File `validate:"required,dive"`
+
+	URL *text.Template `validate:"required"`
+}
+
+func (pkgInfo *HTTPPackageInfo) GetName() string {
+	return pkgInfo.Name
+}
+
+func (pkgInfo *HTTPPackageInfo) GetType() string {
+	return pkgInfoTypeHTTP
+}
+
+func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
+	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
+	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
+		"Package":     pkg,
+		"PackageInfo": pkgInfo,
+		"OS":          runtime.GOOS,
+		"Arch":        runtime.GOARCH,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	u, err := url.Parse(uS) // TODO
+	if err != nil {
+		return "", fmt.Errorf("parse the URL: %w", err)
+	}
+	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), u.Host, u.Path), nil
+}
+
+func (pkgInfo *HTTPPackageInfo) GetFiles() []*File {
+	return pkgInfo.Files
+}
+
+func (pkgInfo *HTTPPackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+		return assetName, nil
+	}
+	if file.Src == nil {
+		return file.Name, nil
+	}
+	src, err := file.RenderSrc(pkg, pkgInfo)
+	if err != nil {
+		return "", fmt.Errorf("render the template file.src: %w", err)
+	}
+	return src, nil
+}
+
+func (pkgInfo *HTTPPackageInfo) RenderURL(pkg *Package) (string, error) {
+	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
+		"Package":     pkg,
+		"PackageInfo": pkgInfo,
+		"OS":          runtime.GOOS,
+		"Arch":        runtime.GOARCH,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	return uS, nil
+}
+
+func (pkgInfo *HTTPPackageInfo) RenderAsset(pkg *Package) (string, error) {
+	uS, err := pkgInfo.RenderURL(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	u, err := url.Parse(uS) // TODO
+	if err != nil {
+		return "", fmt.Errorf("parse the URL: %w", err)
+	}
+	return filepath.Base(u.Path), nil
+}
+
 type File struct {
 	Name string `validate:"required"`
 	Src  *text.Template
 }
 
-func (file *File) RenderSrc(pkg *Package, pkgInfo *PackageInfo) (string, error) {
+func (file *File) RenderSrc(pkg *Package, pkgInfo PackageInfo) (string, error) {
 	return file.Src.Execute(map[string]interface{}{ //nolint:wrapcheck
 		"Package":     pkg,
 		"PackageInfo": pkgInfo,

--- a/pkg/controller/download.go
+++ b/pkg/controller/download.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"errors"
+	"io"
 
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/aqua/pkg/log"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func (ctrl *Controller) download(ctx context.Context, pkg *Package, pkgInfo *PackageInfo, dest, assetName string) error {
+func (ctrl *Controller) download(ctx context.Context, pkg *Package, pkgInfo PackageInfo, dest, assetName string) error {
 	logE := log.New().WithFields(logrus.Fields{
 		"package_name":    pkg.Name,
 		"package_version": pkg.Version,
@@ -16,15 +18,43 @@ func (ctrl *Controller) download(ctx context.Context, pkg *Package, pkgInfo *Pac
 	})
 	logE.Info("download and unarchive the package")
 
-	if pkgInfo.Type == "github_release" && ctrl.GitHub == nil {
-		return errGitHubTokenIsRequired
+	var body io.ReadCloser
+	switch pkgInfo.GetType() {
+	case pkgInfoTypeGitHubRelease:
+		if ctrl.GitHub == nil {
+			return errGitHubTokenIsRequired
+		}
+		p, ok := pkgInfo.(*GitHubReleasePackageInfo)
+		if !ok {
+			return errors.New("pkg typs is github_release, but it isn't *GitHubReleasePackageInfo")
+		}
+		b, err := ctrl.downloadFromGitHub(ctx, p.RepoOwner, p.RepoName, pkg.Version, assetName)
+		if err != nil {
+			return err
+		}
+		body = b
+	case pkgInfoTypeHTTP:
+		p, ok := pkgInfo.(*HTTPPackageInfo)
+		if !ok {
+			return errors.New("pkg typs is http, but it isn't *HTTPPackageInfo")
+		}
+		uS, err := p.RenderURL(pkg)
+		if err != nil {
+			return err
+		}
+		b, err := ctrl.downloadFromURL(ctx, uS)
+		if err != nil {
+			return err
+		}
+		body = b
+	default:
+		return logerr.WithFields(errors.New("invalid type"), logrus.Fields{ //nolint:wrapcheck
+			"package_type": pkgInfo.GetType(),
+		})
 	}
 
-	body, err := ctrl.downloadFromGitHub(ctx, pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName)
-	if err != nil {
-		return err
-	}
-	return unarchive(body, assetName, pkgInfo.ArchiveType, dest)
+	defer body.Close()
+	return unarchive(body, assetName, pkgInfo.GetArchiveType(), dest)
 }
 
 var errGitHubTokenIsRequired = errors.New("GITHUB_TOKEN is required for the type `github_release`")

--- a/pkg/controller/download_github.go
+++ b/pkg/controller/download_github.go
@@ -29,7 +29,7 @@ func (ctrl *Controller) downloadFromGitHub(ctx context.Context, owner, repoName,
 	if body != nil {
 		return body, nil
 	}
-	b, err := ctrl.downloadFromRedirectURL(ctx, redirectURL)
+	b, err := ctrl.downloadFromURL(ctx, redirectURL)
 	if err != nil {
 		if b != nil {
 			b.Close()
@@ -37,19 +37,4 @@ func (ctrl *Controller) downloadFromGitHub(ctx context.Context, owner, repoName,
 		return nil, err
 	}
 	return b, nil
-}
-
-func (ctrl *Controller) downloadFromRedirectURL(ctx context.Context, redirectURL string) (io.ReadCloser, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirectURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("create a HTTP request: %w", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("send the HTTP request: %w", err)
-	}
-	if resp.StatusCode >= 300 { //nolint:gomnd
-		return nil, fmt.Errorf("status code: %d", resp.StatusCode)
-	}
-	return resp.Body, nil
 }

--- a/pkg/controller/download_url.go
+++ b/pkg/controller/download_url.go
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (ctrl *Controller) downloadFromURL(ctx context.Context, u string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create a http request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send http request: %w", err)
+	}
+	if resp.StatusCode >= 400 { //nolint:gomnd
+		return resp.Body, errors.New("status code >= 400")
+	}
+	return resp.Body, nil
+}

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
+)
+
+type GitHubReleasePackageInfo struct {
+	Name        string  `validate:"required"`
+	ArchiveType string  `yaml:"archive_type"`
+	Files       []*File `validate:"required,dive"`
+
+	RepoOwner string         `yaml:"repo_owner" validate:"required"`
+	RepoName  string         `yaml:"repo_name" validate:"required"`
+	Asset     *text.Template `validate:"required"`
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetName() string {
+	return pkgInfo.Name
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetType() string {
+	return pkgInfoTypeGitHubRelease
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
+	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), "github.com", pkgInfo.RepoOwner, pkgInfo.RepoName, pkg.Version, assetName), nil
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetFiles() []*File {
+	return pkgInfo.Files
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+		return assetName, nil
+	}
+	if file.Src == nil {
+		return file.Name, nil
+	}
+	src, err := file.RenderSrc(pkg, pkgInfo)
+	if err != nil {
+		return "", fmt.Errorf("render the template file.src: %w", err)
+	}
+	return src, nil
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) RenderAsset(pkg *Package) (string, error) {
+	return pkgInfo.Asset.Execute(map[string]interface{}{ //nolint:wrapcheck
+		"Package":     pkg,
+		"PackageInfo": pkgInfo,
+		"OS":          runtime.GOOS,
+		"Arch":        runtime.GOARCH,
+	})
+}

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"runtime"
+
+	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
+)
+
+type HTTPPackageInfo struct {
+	Name        string  `validate:"required"`
+	ArchiveType string  `yaml:"archive_type"`
+	Files       []*File `validate:"required,dive"`
+
+	URL *text.Template `validate:"required"`
+}
+
+func (pkgInfo *HTTPPackageInfo) GetName() string {
+	return pkgInfo.Name
+}
+
+func (pkgInfo *HTTPPackageInfo) GetType() string {
+	return pkgInfoTypeHTTP
+}
+
+func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
+	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
+	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
+		"Package":     pkg,
+		"PackageInfo": pkgInfo,
+		"OS":          runtime.GOOS,
+		"Arch":        runtime.GOARCH,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	u, err := url.Parse(uS) // TODO
+	if err != nil {
+		return "", fmt.Errorf("parse the URL: %w", err)
+	}
+	return filepath.Join(rootDir, "pkgs", pkgInfo.GetType(), u.Host, u.Path), nil
+}
+
+func (pkgInfo *HTTPPackageInfo) GetFiles() []*File {
+	return pkgInfo.Files
+}
+
+func (pkgInfo *HTTPPackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render the asset name: %w", err)
+	}
+	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+		return assetName, nil
+	}
+	if file.Src == nil {
+		return file.Name, nil
+	}
+	src, err := file.RenderSrc(pkg, pkgInfo)
+	if err != nil {
+		return "", fmt.Errorf("render the template file.src: %w", err)
+	}
+	return src, nil
+}
+
+func (pkgInfo *HTTPPackageInfo) RenderURL(pkg *Package) (string, error) {
+	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
+		"Package":     pkg,
+		"PackageInfo": pkgInfo,
+		"OS":          runtime.GOOS,
+		"Arch":        runtime.GOARCH,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	return uS, nil
+}
+
+func (pkgInfo *HTTPPackageInfo) RenderAsset(pkg *Package) (string, error) {
+	uS, err := pkgInfo.RenderURL(pkg)
+	if err != nil {
+		return "", fmt.Errorf("render URL: %w", err)
+	}
+	u, err := url.Parse(uS) // TODO
+	if err != nil {
+		return "", fmt.Errorf("parse the URL: %w", err)
+	}
+	return filepath.Base(u.Path), nil
+}

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -39,7 +39,7 @@ func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string
 	if err != nil {
 		return "", fmt.Errorf("render URL: %w", err)
 	}
-	u, err := url.Parse(uS) // TODO
+	u, err := url.Parse(uS)
 	if err != nil {
 		return "", fmt.Errorf("parse the URL: %w", err)
 	}
@@ -86,7 +86,7 @@ func (pkgInfo *HTTPPackageInfo) RenderAsset(pkg *Package) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("render URL: %w", err)
 	}
-	u, err := url.Parse(uS) // TODO
+	u, err := url.Parse(uS)
 	if err != nil {
 		return "", fmt.Errorf("parse the URL: %w", err)
 	}

--- a/pkg/controller/install_proxy.go
+++ b/pkg/controller/install_proxy.go
@@ -24,9 +24,8 @@ func (ctrl *Controller) installProxy(ctx context.Context) error {
 	})
 
 	logE.Debug("install the proxy")
-	pkgInfo := &PackageInfo{
+	pkgInfo := &GitHubReleasePackageInfo{
 		Name:      "inline",
-		Type:      "github_release",
 		RepoOwner: "suzuki-shunsuke",
 		RepoName:  "aqua-proxy",
 		Asset:     nil,
@@ -39,7 +38,10 @@ func (ctrl *Controller) installProxy(ctx context.Context) error {
 
 	assetName := "aqua-proxy_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 
-	pkgPath := getPkgPath(ctrl.RootDir, pkg, pkgInfo, assetName)
+	pkgPath, err := pkgInfo.GetPkgPath(ctrl.RootDir, pkg)
+	if err != nil {
+		return err
+	}
 	logE.Debug("check if the package is already installed")
 	finfo, err := os.Stat(pkgPath)
 	if err != nil {


### PR DESCRIPTION
Close #5

e.g. helm

```yaml
packages:
- name: helm
  registry: inline
  version: v3.6.3 # renovate: depName=helm/helm
inline_registry:
- name: helm
  type: http
  url: https://get.helm.sh/helm-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz
  files:
  - name: helm
    src: "{{.OS}}-{{.Arch}}/helm"
```

```
$ tree ~/.aqua/pkgs/http 
~/.aqua/pkgs/http
└── get.helm.sh
    └── helm-v3.6.3-darwin-amd64.tar.gz
        └── darwin-amd64
            ├── LICENSE
            ├── README.md
            └── helm

3 directories, 3 files
```