### PR TITLE
feat: support Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ e.g.
 ## Related Projects
 
 * [aqua-proxy](https://github.com/suzuki-shunsuke/aqua-proxy)
-* [aqua-installer](https://github.com/suzuki-shunsuke/aqua-installer)
+* [aqua-installer](https://github.com/suzuki-shunsuke/aqua-installer): Install aqua quickly
+* [aqua-registry](https://github.com/suzuki-shunsuke/aqua-registry): Official Registry
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jq-1.6
 * [Tutorial](tutorial/README.md)
 * [Usage](docs/usage.md)
 * [Configuration](docs/config.md)
+* [Registry](docs/registry.md)
 
 ## Main Usecase
 
@@ -84,6 +85,8 @@ jq-1.6
   * When you execute the tool which isn't installed yet, aqua installs the tool and execute the tool
 * Share tools across projects
   * aqua installs tools in the shared directory `~/.aqua`. It saves time and disk to install tools
+* Ecosystem named `Registry` - it eases to write aqua configuration
+  * You can share and reuse the aqua configuration. We provide the official registry too
 
 ## Install
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,6 +19,7 @@ If the confgiuration file path isn't specified, the file named `[.]aqua.y[a]ml` 
 
 * `packages`: The list of installed packages
 * `inline_registry`: The list of package metadata
+* `registries`: The list of registries
 
 ### type: Package
 
@@ -50,7 +51,15 @@ The type `http` has the following fields.
 ### Registry
 
 `Registry` is the list of package metadata.
-Only `inline` registry is supported.
+
+`github_content` registry
+
+* `name`: registy name
+* `type`: registy type. Only `github_content` is supported
+* `repo_owner`: GitHub Repository owner
+* `repo_name`: GitHub Repository name
+* `ref`: GitHub Content ref (e.g. `v0.1.0`)
+* `path`: GitHub Content file path. This must be a file
 
 ### type: File
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,16 @@
+# Registry
+
+`Registry` is the aqua's Ecosystem.
+By `Registry`, you can do the following things.
+
+* Reuse the aqua's Configuration
+* Share your Configuration across projects
+* Publish your Configuration as OSS
+* Contribute to the official Registry or third party Registry
+
+## Official Registry
+
+We maintain the official registry.
+We welcome your contribution!
+
+https://github.com/suzuki-shunsuke/aqua-registry

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -24,6 +24,7 @@ type Package struct {
 type Config struct {
 	Packages       []*Package   `validate:"dive"`
 	InlineRegistry PackageInfos `yaml:"inline_registry" validate:"dive"`
+	Registries     []*Registry  `validate:"dive"`
 }
 
 type PackageInfos []PackageInfo

--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -7,16 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"sync"
 
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/aqua/pkg/log"
-	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
 const proxyName = "aqua-proxy"
 
-func (ctrl *Controller) Install(ctx context.Context, param *Param) error { //nolint:cyclop,funlen
+func (ctrl *Controller) Install(ctx context.Context, param *Param) error {
 	cfg := &Config{}
 	wd, err := os.Getwd()
 	if err != nil {
@@ -35,16 +33,11 @@ func (ctrl *Controller) Install(ctx context.Context, param *Param) error { //nol
 		return fmt.Errorf("configuration is invalid: %w", err)
 	}
 
-	if err := os.MkdirAll(rootBin, 0o775); err != nil { //nolint:gomnd
+	if err := mkdirAll(rootBin); err != nil {
 		return fmt.Errorf("create the directory: %w", err)
 	}
 
-	inlineRegistry, err := cfg.InlineRegistry.ToMap()
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(rootBin, 0o775); err != nil { //nolint:gomnd
+	if err := mkdirAll(rootBin); err != nil {
 		return fmt.Errorf("create the directory: %w", err)
 	}
 
@@ -54,33 +47,16 @@ func (ctrl *Controller) Install(ctx context.Context, param *Param) error { //nol
 		}
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(len(cfg.Packages))
-	var flagMutex sync.Mutex
-	var failed bool
-	maxInstallChan := make(chan struct{}, getMaxParallelism())
-	for _, pkg := range cfg.Packages {
-		go func(pkg *Package) {
-			defer wg.Done()
-			maxInstallChan <- struct{}{}
-			if err := ctrl.installPackage(ctx, inlineRegistry, pkg, rootBin, param.OnlyLink, param.IsTest); err != nil {
-				<-maxInstallChan
-				log.New().WithFields(logrus.Fields{
-					"package_name": pkg.Name,
-				}).WithError(err).Error("install the package")
-				flagMutex.Lock()
-				failed = true
-				flagMutex.Unlock()
-				return
-			}
-			<-maxInstallChan
-		}(pkg)
+	registryContents, err := ctrl.installRegistries(ctx, cfg)
+	if err != nil {
+		return err
 	}
-	wg.Wait()
-	if failed {
-		return errInstallFailure
+
+	registryContents["inline"] = &RegistryContent{
+		PackageInfos: cfg.InlineRegistry,
 	}
-	return nil
+
+	return ctrl.installPackages(ctx, cfg, registryContents, rootBin, param.OnlyLink, param.IsTest)
 }
 
 var errInstallFailure = errors.New("it failed to install some packages")
@@ -103,145 +79,4 @@ func getMaxParallelism() int {
 		return defaultMaxParallelism
 	}
 	return num
-}
-
-func (ctrl *Controller) installPackage(ctx context.Context, inlineRegistry map[string]PackageInfo, pkg *Package, binDir string, onlyLink, isTest bool) error { //nolint:cyclop
-	logE := log.New().WithFields(logrus.Fields{
-		"package_name":    pkg.Name,
-		"package_version": pkg.Version,
-		"registry":        pkg.Registry,
-	})
-	logE.Debug("install the package")
-	if pkg.Registry != "inline" {
-		return fmt.Errorf("only inline registry is supported (%s)", pkg.Registry)
-	}
-	pkgInfo, ok := inlineRegistry[pkg.Name]
-	if !ok {
-		return fmt.Errorf("registry isn't found %s", pkg.Name)
-	}
-
-	assetName, err := pkgInfo.RenderAsset(pkg)
-	if err != nil {
-		return fmt.Errorf("render the asset name: %w", err)
-	}
-
-	for _, file := range pkgInfo.GetFiles() {
-		if err := ctrl.createLink(binDir, file); err != nil {
-			return err
-		}
-	}
-
-	if onlyLink {
-		logE.WithFields(logrus.Fields{
-			"only_link": true,
-		}).Debug("skip downloading the package")
-		return nil
-	}
-
-	pkgPath, err := pkgInfo.GetPkgPath(ctrl.RootDir, pkg)
-	if err != nil {
-		return fmt.Errorf("get the package install path: %w", err)
-	}
-	logE.Debug("check if the package is already installed")
-	finfo, err := os.Stat(pkgPath)
-	if err != nil {
-		// file doesn't exist
-		if err := ctrl.download(ctx, pkg, pkgInfo, pkgPath, assetName); err != nil {
-			return err
-		}
-	} else {
-		if !finfo.IsDir() {
-			return fmt.Errorf("%s isn't a directory", pkgPath)
-		}
-	}
-
-	for _, file := range pkgInfo.GetFiles() {
-		if err := ctrl.warnFileSrc(pkg, pkgInfo, file); err != nil {
-			if isTest {
-				return fmt.Errorf("check file_src is correct: %w", err)
-			}
-			logE.WithError(err).Warn("check file_src is correct")
-		}
-	}
-
-	return nil
-}
-
-func (ctrl *Controller) warnFileSrc(pkg *Package, pkgInfo PackageInfo, file *File) error {
-	fields := logrus.Fields{
-		"file_name": file.Name,
-	}
-
-	fileSrc, err := pkgInfo.GetFileSrc(pkg, file)
-	if err != nil {
-		return fmt.Errorf("get file_src: %w", err)
-	}
-
-	pkgPath, err := pkgInfo.GetPkgPath(ctrl.RootDir, pkg)
-	if err != nil {
-		return fmt.Errorf("get the package install path: %w", err)
-	}
-	exePath := filepath.Join(pkgPath, fileSrc)
-
-	finfo, err := os.Stat(exePath)
-	if err != nil {
-		return fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(err, fields))
-	}
-	if finfo.IsDir() {
-		return logerr.WithFields(errors.New("exe_path is directory"), fields) //nolint:wrapcheck
-	}
-	return nil
-}
-
-func (ctrl *Controller) createLink(binDir string, file *File) error {
-	linkPath := filepath.Join(binDir, file.Name)
-	linkDest := proxyName
-	if fileInfo, err := os.Lstat(linkPath); err == nil {
-		switch mode := fileInfo.Mode(); {
-		case mode.IsDir():
-			// if file is a directory, raise error
-			return fmt.Errorf("%s has already existed and is a directory", linkPath)
-		case mode&os.ModeNamedPipe != 0:
-			// if file is a pipe, raise error
-			return fmt.Errorf("%s has already existed and is a named pipe", linkPath)
-		case mode.IsRegular():
-			// TODO if file is a regular file, remove it and create a symlink.
-			return fmt.Errorf("%s has already existed and is a regular file", linkPath)
-		case mode&os.ModeSymlink != 0:
-			return recreateLink(linkPath, linkDest)
-		default:
-			return fmt.Errorf("unexpected file mode %s: %s", linkPath, mode.String())
-		}
-	}
-	log.New().WithFields(logrus.Fields{
-		"link_file": linkPath,
-		"new":       linkDest,
-	}).Info("create a symbolic link")
-	if err := os.Symlink(linkDest, linkPath); err != nil {
-		return fmt.Errorf("create a symbolic link: %w", err)
-	}
-	return nil
-}
-
-func recreateLink(linkPath, linkDest string) error {
-	lnDest, err := os.Readlink(linkPath)
-	if err != nil {
-		return fmt.Errorf("read a symbolic link (%s): %w", linkPath, err)
-	}
-	if linkDest == lnDest {
-		return nil
-	}
-	// recreate link
-	log.New().WithFields(logrus.Fields{
-		"link_file": linkPath,
-		"old":       lnDest,
-		"new":       linkDest,
-	}).Info("recreate a symbolic link")
-	if err := os.Remove(linkPath); err != nil {
-		return fmt.Errorf("remove a symbolic link (%s): %w", linkPath, err)
-	}
-	if err := os.Symlink(linkDest, linkPath); err != nil {
-		return fmt.Errorf("create a symbolic link: %w", err)
-	}
-	return nil
 }

--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -52,10 +52,6 @@ func (ctrl *Controller) Install(ctx context.Context, param *Param) error {
 		return err
 	}
 
-	registryContents["inline"] = &RegistryContent{
-		PackageInfos: cfg.InlineRegistry,
-	}
-
 	return ctrl.installPackages(ctx, cfg, registryContents, rootBin, param.OnlyLink, param.IsTest)
 }
 

--- a/pkg/controller/install_packages.go
+++ b/pkg/controller/install_packages.go
@@ -1,0 +1,205 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
+)
+
+func (ctrl *Controller) installPackages(ctx context.Context, cfg *Config, registries map[string]*RegistryContent, binDir string, onlyLink, isTest bool) error {
+	var wg sync.WaitGroup
+	wg.Add(len(cfg.Packages))
+	var flagMutex sync.Mutex
+	var failed bool
+	maxInstallChan := make(chan struct{}, getMaxParallelism())
+
+	for _, pkg := range cfg.Packages {
+		go func(pkg *Package) {
+			defer wg.Done()
+			maxInstallChan <- struct{}{}
+			registry, ok := registries[pkg.Registry]
+			if !ok {
+				log.New().WithFields(logrus.Fields{
+					"package_name": pkg.Name,
+				}).Error("install the package")
+				<-maxInstallChan
+				return
+			}
+			pkgInfos, err := registry.PackageInfos.ToMap()
+			if err != nil {
+				<-maxInstallChan
+				log.New().WithFields(logrus.Fields{
+					"package_name": pkg.Name,
+				}).WithError(err).Error("install the package")
+				flagMutex.Lock()
+				failed = true
+				flagMutex.Unlock()
+				return
+			}
+			if err := ctrl.installPackage(ctx, pkgInfos, pkg, binDir, onlyLink, isTest); err != nil {
+				<-maxInstallChan
+				log.New().WithFields(logrus.Fields{
+					"package_name": pkg.Name,
+				}).WithError(err).Error("install the package")
+				flagMutex.Lock()
+				failed = true
+				flagMutex.Unlock()
+				return
+			}
+			<-maxInstallChan
+		}(pkg)
+	}
+	wg.Wait()
+	if failed {
+		return errInstallFailure
+	}
+	return nil
+}
+
+func (ctrl *Controller) installPackage(ctx context.Context, inlineRegistry map[string]PackageInfo, pkg *Package, binDir string, onlyLink, isTest bool) error { //nolint:cyclop
+	logE := log.New().WithFields(logrus.Fields{
+		"package_name":    pkg.Name,
+		"package_version": pkg.Version,
+		"registry":        pkg.Registry,
+	})
+	logE.Debug("install the package")
+	if pkg.Registry != "inline" {
+		return fmt.Errorf("only inline registry is supported (%s)", pkg.Registry)
+	}
+	pkgInfo, ok := inlineRegistry[pkg.Name]
+	if !ok {
+		return fmt.Errorf("registry isn't found %s", pkg.Name)
+	}
+
+	assetName, err := pkgInfo.RenderAsset(pkg)
+	if err != nil {
+		return fmt.Errorf("render the asset name: %w", err)
+	}
+
+	for _, file := range pkgInfo.GetFiles() {
+		if err := ctrl.createLink(binDir, file); err != nil {
+			return err
+		}
+	}
+
+	if onlyLink {
+		logE.WithFields(logrus.Fields{
+			"only_link": true,
+		}).Debug("skip downloading the package")
+		return nil
+	}
+
+	pkgPath, err := pkgInfo.GetPkgPath(ctrl.RootDir, pkg)
+	if err != nil {
+		return fmt.Errorf("get the package install path: %w", err)
+	}
+	logE.Debug("check if the package is already installed")
+	finfo, err := os.Stat(pkgPath)
+	if err != nil {
+		// file doesn't exist
+		if err := ctrl.download(ctx, pkg, pkgInfo, pkgPath, assetName); err != nil {
+			return err
+		}
+	} else {
+		if !finfo.IsDir() {
+			return fmt.Errorf("%s isn't a directory", pkgPath)
+		}
+	}
+
+	for _, file := range pkgInfo.GetFiles() {
+		if err := ctrl.warnFileSrc(pkg, pkgInfo, file); err != nil {
+			if isTest {
+				return fmt.Errorf("check file_src is correct: %w", err)
+			}
+			logE.WithError(err).Warn("check file_src is correct")
+		}
+	}
+
+	return nil
+}
+
+func (ctrl *Controller) warnFileSrc(pkg *Package, pkgInfo PackageInfo, file *File) error {
+	fields := logrus.Fields{
+		"file_name": file.Name,
+	}
+
+	fileSrc, err := pkgInfo.GetFileSrc(pkg, file)
+	if err != nil {
+		return fmt.Errorf("get file_src: %w", err)
+	}
+
+	pkgPath, err := pkgInfo.GetPkgPath(ctrl.RootDir, pkg)
+	if err != nil {
+		return fmt.Errorf("get the package install path: %w", err)
+	}
+	exePath := filepath.Join(pkgPath, fileSrc)
+
+	finfo, err := os.Stat(exePath)
+	if err != nil {
+		return fmt.Errorf("exe_path isn't found: %w", logerr.WithFields(err, fields))
+	}
+	if finfo.IsDir() {
+		return logerr.WithFields(errors.New("exe_path is directory"), fields) //nolint:wrapcheck
+	}
+	return nil
+}
+
+func (ctrl *Controller) createLink(binDir string, file *File) error {
+	linkPath := filepath.Join(binDir, file.Name)
+	linkDest := proxyName
+	if fileInfo, err := os.Lstat(linkPath); err == nil {
+		switch mode := fileInfo.Mode(); {
+		case mode.IsDir():
+			// if file is a directory, raise error
+			return fmt.Errorf("%s has already existed and is a directory", linkPath)
+		case mode&os.ModeNamedPipe != 0:
+			// if file is a pipe, raise error
+			return fmt.Errorf("%s has already existed and is a named pipe", linkPath)
+		case mode.IsRegular():
+			// TODO if file is a regular file, remove it and create a symlink.
+			return fmt.Errorf("%s has already existed and is a regular file", linkPath)
+		case mode&os.ModeSymlink != 0:
+			return recreateLink(linkPath, linkDest)
+		default:
+			return fmt.Errorf("unexpected file mode %s: %s", linkPath, mode.String())
+		}
+	}
+	log.New().WithFields(logrus.Fields{
+		"link_file": linkPath,
+		"new":       linkDest,
+	}).Info("create a symbolic link")
+	if err := os.Symlink(linkDest, linkPath); err != nil {
+		return fmt.Errorf("create a symbolic link: %w", err)
+	}
+	return nil
+}
+
+func recreateLink(linkPath, linkDest string) error {
+	lnDest, err := os.Readlink(linkPath)
+	if err != nil {
+		return fmt.Errorf("read a symbolic link (%s): %w", linkPath, err)
+	}
+	if linkDest == lnDest {
+		return nil
+	}
+	// recreate link
+	log.New().WithFields(logrus.Fields{
+		"link_file": linkPath,
+		"old":       lnDest,
+		"new":       linkDest,
+	}).Info("recreate a symbolic link")
+	if err := os.Remove(linkPath); err != nil {
+		return fmt.Errorf("remove a symbolic link (%s): %w", linkPath, err)
+	}
+	if err := os.Symlink(linkDest, linkPath); err != nil {
+		return fmt.Errorf("create a symbolic link: %w", err)
+	}
+	return nil
+}

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -35,6 +35,10 @@ func (ctrl *Controller) installRegistries(ctx context.Context, cfg *Config) (map
 	var failed bool
 	maxInstallChan := make(chan struct{}, getMaxParallelism())
 	registryContents := make(map[string]*RegistryContent, len(cfg.Registries)+1)
+	registryContents["inline"] = &RegistryContent{
+		PackageInfos: cfg.InlineRegistry,
+	}
+
 	for _, registry := range cfg.Registries {
 		go func(registry *Registry) {
 			defer wg.Done()

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/go-github/v38/github"
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/aqua/pkg/log"
+	"gopkg.in/yaml.v2"
+)
+
+type Registry struct {
+	Name      string `validate:"required"`
+	Type      string `validate:"required"`
+	RepoOwner string `yaml:"repo_owner"`
+	RepoName  string `yaml:"repo_name"`
+	Ref       string `validate:"required"`
+	Path      string `validate:"required"`
+}
+
+type RegistryContent struct {
+	PackageInfos PackageInfos `yaml:"package_infos"`
+}
+
+func (ctrl *Controller) installRegistries(ctx context.Context, cfg *Config) (map[string]*RegistryContent, error) {
+	var wg sync.WaitGroup
+	wg.Add(len(cfg.Registries))
+	var flagMutex sync.Mutex
+	var registriesMutex sync.Mutex
+	var failed bool
+	maxInstallChan := make(chan struct{}, getMaxParallelism())
+	registryContents := make(map[string]*RegistryContent, len(cfg.Registries)+1)
+	for _, registry := range cfg.Registries {
+		go func(registry *Registry) {
+			defer wg.Done()
+			maxInstallChan <- struct{}{}
+			registryContent, err := ctrl.installRegistry(ctx, registry)
+			if err != nil {
+				<-maxInstallChan
+				log.New().WithFields(logrus.Fields{
+					"registry_name": registry.Name,
+				}).WithError(err).Error("install the registry")
+				flagMutex.Lock()
+				failed = true
+				flagMutex.Unlock()
+				return
+			}
+			registriesMutex.Lock()
+			registryContents[registry.Name] = registryContent
+			registriesMutex.Unlock()
+			<-maxInstallChan
+		}(registry)
+	}
+	wg.Wait()
+	if failed {
+		return nil, errInstallFailure
+	}
+
+	return registryContents, nil
+}
+
+func (ctrl *Controller) installRegistry(ctx context.Context, registry *Registry) (*RegistryContent, error) { //nolint:cyclop
+	if registry.Type != "github_content" {
+		return nil, fmt.Errorf("only inline or github_content registry is supported (%s)", registry.Type)
+	}
+
+	// TODO check if file exists
+	registryFilePath := filepath.Join(ctrl.RootDir, "registries", registry.Type, "github.com", registry.RepoOwner, registry.RepoName, registry.Ref, registry.Path)
+	if _, err := os.Stat(registryFilePath); err != nil { //nolint:nestif
+		// file doesn't exist
+		// download and install file
+		if ctrl.GitHub == nil {
+			return nil, errGitHubTokenIsRequired
+		}
+		file, _, _, err := ctrl.GitHub.Repositories.GetContents(ctx, registry.RepoOwner, registry.RepoName, registry.Path, &github.RepositoryContentGetOptions{
+			Ref: registry.Ref,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get the registry configuration file by Get GitHub Content API: %w", err)
+		}
+		if file == nil {
+			return nil, errors.New("ref must be not a directory but a file")
+		}
+		content, err := file.GetContent()
+		if err != nil {
+			return nil, fmt.Errorf("get the registry configuration content: %w", err)
+		}
+
+		if err := mkdirAll(filepath.Dir(registryFilePath)); err != nil {
+			return nil, fmt.Errorf("create the parent directory of the configuration file: %w", err)
+		}
+		if err := os.WriteFile(registryFilePath, []byte(content), 0o600); err != nil { //nolint:gomnd
+			return nil, fmt.Errorf("write the configuration file: %w", err)
+		}
+		registryContent := &RegistryContent{}
+		if err := yaml.Unmarshal([]byte(content), registryContent); err != nil {
+			return nil, fmt.Errorf("parse the registry configuration file: %w", err)
+		}
+		return registryContent, nil
+	}
+
+	f, err := os.Open(registryFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open the registry configuration file: %w", err)
+	}
+	defer f.Close()
+	registryContent := &RegistryContent{}
+	decoder := yaml.NewDecoder(f)
+	decoder.SetStrict(true)
+	if err := decoder.Decode(registryContent); err != nil {
+		return nil, fmt.Errorf("parse the registry configuration: %w", err)
+	}
+	return registryContent, nil
+}

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -24,7 +24,7 @@ type Registry struct {
 }
 
 type RegistryContent struct {
-	PackageInfos PackageInfos `yaml:"package_infos"`
+	PackageInfos PackageInfos `yaml:"packages"`
 }
 
 func (ctrl *Controller) installRegistries(ctx context.Context, cfg *Config) (map[string]*RegistryContent, error) {

--- a/pkg/controller/unarchive.go
+++ b/pkg/controller/unarchive.go
@@ -21,7 +21,7 @@ func getUnarchiver(filename, typ string) (interface{}, error) {
 func unarchive(body io.Reader, filename, typ, dest string) error { //nolint:cyclop
 	if isUnarchived(typ, filename) {
 		log.New().Debug("archive type is raw")
-		if err := os.MkdirAll(dest, 0o775); err != nil { //nolint:gomnd
+		if err := mkdirAll(dest); err != nil {
 			return fmt.Errorf("create a directory (%s): %w", dest, err)
 		}
 		f, err := os.OpenFile(filepath.Join(dest, filename), os.O_RDWR|os.O_CREATE, 0o755) //nolint:gomnd

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1,0 +1,7 @@
+package controller
+
+import "os"
+
+func mkdirAll(p string) error {
+	return os.MkdirAll(p, 0o775) //nolint:gomnd,wrapcheck
+}


### PR DESCRIPTION
Close #7

Support `github_content` Registry.

aqua.yaml

```yaml
packages:
- name: golangci-lint
  registry: official
  version: v1.42.0 # renovate: depName=golangci/golangci-lint
registries:
- name: official
  type: github_content
  repo_owner: suzuki-shunsuke
  repo_name: aqua-registry
  ref: v0.1.1-0
  path: registry.yaml
```

https://github.com/suzuki-shunsuke/aqua-registry