### PR TITLE
feat: change the inline registry structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ packages:
   registry: inline
   version: jq-1.5
 inline_registry:
-- name: jq
-  type: github_release
-  repo_owner: stedolan
-  repo_name: jq
-  asset: 'jq-{{if eq .OS "darwin"}}osx{{else}}{{.OS}}{{end}}-{{.Arch}}'
-  files:
+  packages:
   - name: jq
+    type: github_release
+    repo_owner: stedolan
+    repo_name: jq
+    asset: 'jq-{{if eq .OS "darwin"}}osx{{else}}{{.OS}}{{end}}-{{.Arch}}'
+    files:
+    - name: jq
 ```
 
 Install tools.

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -5,17 +5,21 @@ registries:
   repo_name: aqua-registry
   ref: v0.1.1-0
   path: registry.yaml
+
 - name: local
   type: local
   path: registry.yaml
+
 inline_registry:
-- name: cmdx
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: cmdx
-  asset: 'cmdx_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  files:
+  packages:
   - name: cmdx
+    type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: cmdx
+    asset: 'cmdx_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+    files:
+    - name: cmdx
+
 packages:
 - name: cmdx
   registry: inline

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,8 +18,12 @@ If the confgiuration file path isn't specified, the file named `[.]aqua.y[a]ml` 
 ## Configuration File Format
 
 * `packages`: The list of installed packages
-* `inline_registry`: The list of package metadata
+* `inline_registry`: The inline registry
 * `registries`: The list of registries
+
+### type: Inline Registry
+
+* `packages`: The list of package metadata
 
 ### type: Package
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -22,9 +22,13 @@ type Package struct {
 }
 
 type Config struct {
-	Packages       []*Package   `validate:"dive"`
-	InlineRegistry PackageInfos `yaml:"inline_registry" validate:"dive"`
-	Registries     Registries   `validate:"dive"`
+	Packages       []*Package      `validate:"dive"`
+	InlineRegistry *InlineRegistry `yaml:"inline_registry" validate:"dive"`
+	Registries     Registries      `validate:"dive"`
+}
+
+type InlineRegistry struct {
+	Packages PackageInfos `validate:"dive"`
 }
 
 type (

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -108,7 +108,7 @@ func (ctrl *Controller) installRegistries(ctx context.Context, cfg *Config, cfgF
 	maxInstallChan := make(chan struct{}, getMaxParallelism())
 	registryContents := make(map[string]*RegistryContent, len(cfg.Registries)+1)
 	registryContents["inline"] = &RegistryContent{
-		PackageInfos: cfg.InlineRegistry,
+		PackageInfos: cfg.InlineRegistry.Packages,
 	}
 
 	for _, registry := range cfg.Registries {

--- a/tutorial/aqua.yaml
+++ b/tutorial/aqua.yaml
@@ -1,13 +1,26 @@
+registries:
+- name: official
+  type: github_content
+  repo_owner: suzuki-shunsuke
+  repo_name: aqua-registry
+  ref: v0.1.1-0 # renovate: depName=suzuki-shunsuke/aqua-registry
+  path: registry.yaml
 packages:
-- name: gh
-  registry: inline
-  version: v1.13.1
-inline_registry:
-- name: gh
-  type: github_release
-  repo_owner: cli
-  repo_name: cli
-  asset: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}.tar.gz'
-  files:
-  - name: gh
-    src: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}/bin/gh'
+- name: direnv
+  registry: official
+  version: v2.28.0 # renovate: depName=direnv/direnv
+- name: golangci-lint
+  registry: official
+  version: v1.42.0 # renovate: depName=golangci/golangci-lint
+- name: helmfile
+  registry: official
+  version: v0.140.0 # renovate: depName=roboll/helmfile
+- name: jq
+  registry: official
+  version: jq-1.6
+- name: kustomize
+  registry: official
+  version: kustomize/v3.9.4 # TODO renovate
+- name: opa
+  registry: official
+  version: v0.32.0 # renovate: depName=open-policy-agent/opa

--- a/tutorial/docker-compose.yml
+++ b/tutorial/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        aqua_version: v0.3.1
+        aqua_version: v0.3.2-2
         aqua_installer_version: v0.1.2
     tty: true
     stdin_open: true


### PR DESCRIPTION
BREAKING CHANGE: `inline_registry`'s structure is changed

The field `packages` is added.

AS IS

```yaml
inline_registry:
- name: jq
  type: github_release
  repo_owner: stedolan
  repo_name: jq
  asset: 'jq-{{if eq .OS "darwin"}}osx{{else}}{{.OS}}{{end}}-{{.Arch}}'
  files:
  - name: jq
```

TO BE

```yaml
inline_registry:
  packages:
  - name: jq
    type: github_release
    repo_owner: stedolan
    repo_name: jq
    asset: 'jq-{{if eq .OS "darwin"}}osx{{else}}{{.OS}}{{end}}-{{.Arch}}'
    files:
    - name: jq
```