### PR TITLE
fix: fix validator tag "dive"

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -23,7 +23,7 @@ type Package struct {
 
 type Config struct {
 	Packages       []*Package       `validate:"dive"`
-	InlineRegistry *RegistryContent `yaml:"inline_registry" validate:"dive"`
+	InlineRegistry *RegistryContent `yaml:"inline_registry"`
 	Registries     Registries       `validate:"dive"`
 }
 

--- a/pkg/controller/registry.go
+++ b/pkg/controller/registry.go
@@ -105,7 +105,7 @@ func (registry *LocalRegistry) GetFilePath(rootDir, cfgFilePath string) string {
 }
 
 type RegistryContent struct {
-	PackageInfos PackageInfos `yaml:"packages"`
+	PackageInfos PackageInfos `yaml:"packages" validate:"dive"`
 }
 
 func (ctrl *Controller) installRegistries(ctx context.Context, cfg *Config, cfgFilePath string) (map[string]*RegistryContent, error) {


### PR DESCRIPTION
Follow up #158

```
bash-5.1# aqua install
FATA[0000] aqua failed                                   error="configuration is invalid: Key: 'Config.InlineRegistry' Error:Field validation for 'InlineRegistry' failed on the 'dive' tag" program=aqua
```

https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Dive