### PR TITLE
fix: handle the negative index of `previewFunc`

### DIFF
--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -51,6 +51,9 @@ func (ctrl *Controller) Generate(ctx context.Context, param *Param) error { //no
 		return fmt.Sprintf("%s (%s)", pkg.PackageInfo.GetName(), pkg.RegistryName)
 	},
 		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
+			if i < 0 {
+				return ""
+			}
 			pkg := pkgs[i]
 			return fmt.Sprintf("%s\n\n%s\n%s",
 				pkg.PackageInfo.GetName(),


### PR DESCRIPTION
Close #218

https://pkg.go.dev/github.com/ktr0731/go-fuzzyfinder#WithPreviewWindow

> If there is no selected item, previewFunc passes -1 to previewFunc.