### PR TITLE
feat: support replacements

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -103,42 +103,50 @@ type PackageInfo interface {
 }
 
 type mergedPackageInfo struct {
-	Name         string
-	Type         string
-	RepoOwner    string `yaml:"repo_owner"`
-	RepoName     string `yaml:"repo_name"`
-	Asset        *text.Template
-	ArchiveType  string `yaml:"archive_type"`
-	Files        []*File
-	URL          *text.Template
-	Description  string
-	Link         string
-	Replacements map[string]string
+	Name                 string
+	Type                 string
+	RepoOwner            string `yaml:"repo_owner"`
+	RepoName             string `yaml:"repo_name"`
+	Asset                *text.Template
+	ArchiveType          string `yaml:"archive_type"`
+	Files                []*File
+	URL                  *text.Template
+	Description          string
+	Link                 string
+	Replacements         map[string]string
+	ArchiveTypeOverrides []*ArchiveTypeOverride `yaml:"archive_type_overrides"`
+}
+
+type ArchiveTypeOverride struct {
+	GOOS        string
+	ArchiveType string `yaml:"archive_type"`
 }
 
 func (pkgInfo *mergedPackageInfo) GetPackageInfo() (PackageInfo, error) {
 	switch pkgInfo.Type {
 	case pkgInfoTypeGitHubRelease:
 		return &GitHubReleasePackageInfo{
-			Name:         pkgInfo.Name,
-			RepoOwner:    pkgInfo.RepoOwner,
-			RepoName:     pkgInfo.RepoName,
-			Asset:        pkgInfo.Asset,
-			ArchiveType:  pkgInfo.ArchiveType,
-			Files:        pkgInfo.Files,
-			Link:         pkgInfo.Link,
-			Description:  pkgInfo.Description,
-			Replacements: pkgInfo.Replacements,
+			Name:                 pkgInfo.Name,
+			RepoOwner:            pkgInfo.RepoOwner,
+			RepoName:             pkgInfo.RepoName,
+			Asset:                pkgInfo.Asset,
+			ArchiveType:          pkgInfo.ArchiveType,
+			ArchiveTypeOverrides: pkgInfo.ArchiveTypeOverrides,
+			Files:                pkgInfo.Files,
+			Link:                 pkgInfo.Link,
+			Description:          pkgInfo.Description,
+			Replacements:         pkgInfo.Replacements,
 		}, nil
 	case pkgInfoTypeHTTP:
 		return &HTTPPackageInfo{
-			Name:         pkgInfo.Name,
-			ArchiveType:  pkgInfo.ArchiveType,
-			URL:          pkgInfo.URL,
-			Files:        pkgInfo.Files,
-			Link:         pkgInfo.Link,
-			Description:  pkgInfo.Description,
-			Replacements: pkgInfo.Replacements,
+			Name:                 pkgInfo.Name,
+			ArchiveType:          pkgInfo.ArchiveType,
+			ArchiveTypeOverrides: pkgInfo.ArchiveTypeOverrides,
+			URL:                  pkgInfo.URL,
+			Files:                pkgInfo.Files,
+			Link:                 pkgInfo.Link,
+			Description:          pkgInfo.Description,
+			Replacements:         pkgInfo.Replacements,
 		}, nil
 	default:
 		return nil, logerr.WithFields(errInvalidType, logrus.Fields{ //nolint:wrapcheck

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -9,15 +9,16 @@ import (
 )
 
 type GitHubReleasePackageInfo struct {
-	Name         string `validate:"required"`
-	ArchiveType  string `yaml:"archive_type"`
-	Link         string
-	Description  string
-	Files        []*File `validate:"required,dive"`
-	Replacements map[string]string
+	Name                 string `validate:"required"`
+	ArchiveType          string
+	Link                 string
+	Description          string
+	Files                []*File `validate:"required,dive"`
+	Replacements         map[string]string
+	ArchiveTypeOverrides []*ArchiveTypeOverride
 
-	RepoOwner string         `yaml:"repo_owner" validate:"required"`
-	RepoName  string         `yaml:"repo_name" validate:"required"`
+	RepoOwner string
+	RepoName  string
 	Asset     *text.Template `validate:"required"`
 }
 
@@ -38,6 +39,11 @@ func (pkgInfo *GitHubReleasePackageInfo) GetDescription() string {
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
+	for _, arcTypeOverride := range pkgInfo.ArchiveTypeOverrides {
+		if arcTypeOverride.GOOS == runtime.GOOS {
+			return arcTypeOverride.ArchiveType
+		}
+	}
 	return pkgInfo.ArchiveType
 }
 

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -9,11 +9,12 @@ import (
 )
 
 type GitHubReleasePackageInfo struct {
-	Name        string `validate:"required"`
-	ArchiveType string `yaml:"archive_type"`
-	Link        string
-	Description string
-	Files       []*File `validate:"required,dive"`
+	Name         string `validate:"required"`
+	ArchiveType  string `yaml:"archive_type"`
+	Link         string
+	Description  string
+	Files        []*File `validate:"required,dive"`
+	Replacements map[string]string
 
 	RepoOwner string         `yaml:"repo_owner" validate:"required"`
 	RepoName  string         `yaml:"repo_name" validate:"required"`
@@ -38,6 +39,10 @@ func (pkgInfo *GitHubReleasePackageInfo) GetDescription() string {
 
 func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
 	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *GitHubReleasePackageInfo) GetReplacements() map[string]string {
+	return pkgInfo.Replacements
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
@@ -76,5 +81,9 @@ func (pkgInfo *GitHubReleasePackageInfo) RenderAsset(pkg *Package) (string, erro
 		"PackageInfo": pkgInfo,
 		"OS":          runtime.GOOS,
 		"Arch":        runtime.GOARCH,
+		"Replacements": map[string]interface{}{
+			"OS":   replace(runtime.GOOS, pkgInfo.Replacements),
+			"Arch": replace(runtime.GOARCH, pkgInfo.Replacements),
+		},
 	})
 }

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -10,12 +10,13 @@ import (
 )
 
 type HTTPPackageInfo struct {
-	Name         string `validate:"required"`
-	ArchiveType  string `yaml:"archive_type"`
-	Description  string
-	Link         string
-	Files        []*File `validate:"required,dive"`
-	Replacements map[string]string
+	Name                 string `validate:"required"`
+	ArchiveType          string
+	Description          string
+	Link                 string
+	Files                []*File `validate:"required,dive"`
+	Replacements         map[string]string
+	ArchiveTypeOverrides []*ArchiveTypeOverride
 
 	URL *text.Template `validate:"required"`
 }
@@ -37,6 +38,11 @@ func (pkgInfo *HTTPPackageInfo) GetDescription() string {
 }
 
 func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
+	for _, arcTypeOverride := range pkgInfo.ArchiveTypeOverrides {
+		if arcTypeOverride.GOOS == runtime.GOOS {
+			return arcTypeOverride.ArchiveType
+		}
+	}
 	return pkgInfo.ArchiveType
 }
 

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -10,11 +10,12 @@ import (
 )
 
 type HTTPPackageInfo struct {
-	Name        string `validate:"required"`
-	ArchiveType string `yaml:"archive_type"`
-	Description string
-	Link        string
-	Files       []*File `validate:"required,dive"`
+	Name         string `validate:"required"`
+	ArchiveType  string `yaml:"archive_type"`
+	Description  string
+	Link         string
+	Files        []*File `validate:"required,dive"`
+	Replacements map[string]string
 
 	URL *text.Template `validate:"required"`
 }
@@ -37,6 +38,10 @@ func (pkgInfo *HTTPPackageInfo) GetDescription() string {
 
 func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
 	return pkgInfo.ArchiveType
+}
+
+func (pkgInfo *HTTPPackageInfo) GetReplacements() map[string]string {
+	return pkgInfo.Replacements
 }
 
 func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
@@ -84,6 +89,10 @@ func (pkgInfo *HTTPPackageInfo) RenderURL(pkg *Package) (string, error) {
 		"PackageInfo": pkgInfo,
 		"OS":          runtime.GOOS,
 		"Arch":        runtime.GOARCH,
+		"Replacements": map[string]interface{}{
+			"OS":   replace(runtime.GOOS, pkgInfo.Replacements),
+			"Arch": replace(runtime.GOARCH, pkgInfo.Replacements),
+		},
 	})
 	if err != nil {
 		return "", fmt.Errorf("render URL: %w", err)

--- a/pkg/controller/replacements.go
+++ b/pkg/controller/replacements.go
@@ -1,0 +1,9 @@
+package controller
+
+func replace(key string, replacements map[string]string) string {
+	a := replacements[key]
+	if a == "" {
+		return key
+	}
+	return a
+}


### PR DESCRIPTION
e.g.

```yaml

inline_registry:
  packages:
  - name: accurics/terrascan
    type: github_release
    repo_owner: accurics
    repo_name: terrascan
    asset: 'terrascan_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{.Replacements.Arch}}.tar.gz'
    files:
    - name: terrascan
    replacements:
      amd64: x86_64
  - name: fujiwara/lambroll
    type: github_release
    repo_owner: fujiwara
    repo_name: lambroll
    archive_type: tar.gz
    archive_type_overrides:
    - goos: darwin
      archive_type: zip
    asset: 'lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{.PackageInfo.GetArchiveType}}'
    files:
    - name: lambroll
      src: lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}/lambroll

packages:
- name: accurics/terrascan
  registry: inline
  version: v1.9.0

- name: fujiwara/lambroll
  registry: inline
  version: v0.11.8
```