### PR TITLE
feat: add list command and generate's `-f` option

### DIFF
--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -14,6 +14,7 @@ func (runner *Runner) setCLIArg(c *cli.Context, param *controller.Param) error {
 	param.ConfigFilePath = c.String("config")
 	param.OnlyLink = c.Bool("only-link")
 	param.IsTest = c.Bool("test")
+	param.File = c.String("f")
 	return nil
 }
 

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/suzuki-shunsuke/aqua/pkg/controller"
+	"github.com/urfave/cli/v2"
+)
+
+func (runner *Runner) listAction(c *cli.Context) error {
+	param := &controller.Param{}
+	if err := runner.setCLIArg(c, param); err != nil {
+		return fmt.Errorf("parse the command line arguments: %w", err)
+	}
+
+	ctrl, err := controller.New(c.Context, param)
+	if err != nil {
+		return fmt.Errorf("initialize a controller: %w", err)
+	}
+
+	return ctrl.List(c.Context, param, c.Args().Slice()) //nolint:wrapcheck
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -78,6 +78,12 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error { //nolint:
 				Aliases: []string{"g"},
 				Usage:   "Search packages in registries and output the configuration interactively",
 				Action:  runner.generateAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "f",
+						Usage: "the file path of packages list.",
+					},
+				},
 			},
 			{
 				Name:   "version",

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -69,6 +69,11 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error { //nolint:
 				Action: runner.execAction,
 			},
 			{
+				Name:   "list",
+				Usage:  "List packages in Registries",
+				Action: runner.listAction,
+			},
+			{
 				Name:    "generate",
 				Aliases: []string{"g"},
 				Usage:   "Search packages in registries and output the configuration interactively",

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -183,6 +183,7 @@ type Param struct {
 	LogLevel       string
 	OnlyLink       bool
 	IsTest         bool
+	File           string
 }
 
 var errConfigFileNotFound = errors.New("configuration file isn't found")

--- a/pkg/controller/list.go
+++ b/pkg/controller/list.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+func (ctrl *Controller) List(ctx context.Context, param *Param, args []string) error {
+	cfg := &Config{}
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get the current directory: %w", err)
+	}
+	param.ConfigFilePath = ctrl.getConfigFilePath(wd, param.ConfigFilePath)
+	if param.ConfigFilePath == "" {
+		return errConfigFileNotFound
+	}
+	if err := ctrl.readConfig(param.ConfigFilePath, cfg); err != nil {
+		return err
+	}
+
+	if err := validate.Struct(cfg); err != nil {
+		return fmt.Errorf("configuration is invalid: %w", err)
+	}
+
+	registryContents, err := ctrl.installRegistries(ctx, cfg, param.ConfigFilePath)
+	if err != nil {
+		return err
+	}
+	for registryName, registryContent := range registryContents {
+		for _, pkgInfo := range registryContent.PackageInfos {
+			fmt.Fprintln(ctrl.Stdout, registryName+","+pkgInfo.GetName())
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
$ aqua list
```

```
$ aqua list | aqua g -f -
```

## Breaking Change

`aqua generate` is changed.
You can't select the version interactively.
Instead of selecting the version, the latest version except for prereleases is gotten automatically.