### PR TITLE
feat: set the default package name and link to `github_release` package

### DIFF
--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GitHubReleasePackageInfo struct {
-	Name                 string `validate:"required"`
+	Name                 string
 	ArchiveType          string
 	Link                 string
 	Description          string
@@ -23,7 +23,10 @@ type GitHubReleasePackageInfo struct {
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetName() string {
-	return pkgInfo.Name
+	if pkgInfo.Name != "" {
+		return pkgInfo.Name
+	}
+	return pkgInfo.RepoOwner + "/" + pkgInfo.RepoName
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetType() string {

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -34,7 +34,10 @@ func (pkgInfo *GitHubReleasePackageInfo) GetType() string {
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetLink() string {
-	return pkgInfo.Link
+	if pkgInfo.Link != "" {
+		return pkgInfo.Link
+	}
+	return "https://github.com/" + pkgInfo.RepoOwner + "/" + pkgInfo.RepoName
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetDescription() string {


### PR DESCRIPTION
Close #272

* default package name: `<repo owner>/<repo name>`
* default link: `https://github.com/<repo owner>/<repo name>`