### PR TITLE
feat: replace `archive_type` to `format` and set the default `files` of `github_release` package

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,9 +38,9 @@ PackageInfo is the package metadata how the package is installed.
 
 * `name`: the package name
 * `type`: the package type. Either `github_release` or `http` is supported
-* `archive_type`: the archive type (e.g. `zip`, `tar.gz`). Basically you don't have to specify this field because `aqua` understand the archive type from the filename extension.
-  If the `archive_type` is `raw` or the filename has no extension, `aqua` treats the file isn't archived and uncompressed.
-* `archive_type_overrides`
+* `format`: the archive type (e.g. `zip`, `tar.gz`). Basically you don't have to specify this field because `aqua` understand the archive type from the filename extension.
+  If the `format` is `raw` or the filename has no extension, `aqua` treats the file isn't archived and uncompressed.
+* `format_overrides`
 * `replacements`
 * `description`
 * `link`
@@ -118,7 +118,7 @@ The following variables are passed to the template.
 * `GOOS`: Go's [runtime.GOOS](https://pkg.go.dev/runtime#pkg-constants)
 * `GOARCH`: Go's [runtime.GOARCH](https://pkg.go.dev/runtime#pkg-constants)
 * `Version`
-* `ArchiveType`
+* `Format`
 
 #### `File.src`
 
@@ -129,5 +129,5 @@ The following variables are passed to the template.
 * `GOOS`: Go's [runtime.GOOS](https://pkg.go.dev/runtime#pkg-constants)
 * `GOARCH`: Go's [runtime.GOARCH](https://pkg.go.dev/runtime#pkg-constants)
 * `Version`
-* `ArchiveType`
+* `Format`
 * `FileName`

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -45,12 +45,13 @@ var (
 func (pkgInfos *PackageInfos) ToMap() (map[string]PackageInfo, error) {
 	m := make(map[string]PackageInfo, len(*pkgInfos))
 	for _, pkgInfo := range *pkgInfos {
-		if _, ok := m[pkgInfo.GetName()]; ok {
+		name := pkgInfo.GetName()
+		if _, ok := m[name]; ok {
 			return nil, logerr.WithFields(errPkgInfoNameIsDuplicated, logrus.Fields{ //nolint:wrapcheck
-				"package_info_name": pkgInfo.GetName(),
+				"package_info_name": name,
 			})
 		}
-		m[pkgInfo.GetName()] = pkgInfo
+		m[name] = pkgInfo
 	}
 	return m, nil
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -92,7 +92,7 @@ func (registries *Registries) UnmarshalYAML(unmarshal func(interface{}) error) e
 type PackageInfo interface {
 	GetName() string
 	GetType() string
-	GetArchiveType() string
+	GetFormat() string
 	GetFiles() []*File
 	GetFileSrc(pkg *Package, file *File) (string, error)
 	GetPkgPath(rootDir string, pkg *Package) (string, error)
@@ -103,50 +103,50 @@ type PackageInfo interface {
 }
 
 type mergedPackageInfo struct {
-	Name                 string
-	Type                 string
-	RepoOwner            string `yaml:"repo_owner"`
-	RepoName             string `yaml:"repo_name"`
-	Asset                *text.Template
-	ArchiveType          string `yaml:"archive_type"`
-	Files                []*File
-	URL                  *text.Template
-	Description          string
-	Link                 string
-	Replacements         map[string]string
-	ArchiveTypeOverrides []*ArchiveTypeOverride `yaml:"archive_type_overrides"`
+	Name            string
+	Type            string
+	RepoOwner       string `yaml:"repo_owner"`
+	RepoName        string `yaml:"repo_name"`
+	Asset           *text.Template
+	Format          string `yaml:"format"`
+	Files           []*File
+	URL             *text.Template
+	Description     string
+	Link            string
+	Replacements    map[string]string
+	FormatOverrides []*FormatOverride `yaml:"format_overrides"`
 }
 
-type ArchiveTypeOverride struct {
-	GOOS        string
-	ArchiveType string `yaml:"archive_type"`
+type FormatOverride struct {
+	GOOS   string
+	Format string `yaml:"format"`
 }
 
 func (pkgInfo *mergedPackageInfo) GetPackageInfo() (PackageInfo, error) {
 	switch pkgInfo.Type {
 	case pkgInfoTypeGitHubRelease:
 		return &GitHubReleasePackageInfo{
-			Name:                 pkgInfo.Name,
-			RepoOwner:            pkgInfo.RepoOwner,
-			RepoName:             pkgInfo.RepoName,
-			Asset:                pkgInfo.Asset,
-			ArchiveType:          pkgInfo.ArchiveType,
-			ArchiveTypeOverrides: pkgInfo.ArchiveTypeOverrides,
-			Files:                pkgInfo.Files,
-			Link:                 pkgInfo.Link,
-			Description:          pkgInfo.Description,
-			Replacements:         pkgInfo.Replacements,
+			Name:            pkgInfo.Name,
+			RepoOwner:       pkgInfo.RepoOwner,
+			RepoName:        pkgInfo.RepoName,
+			Asset:           pkgInfo.Asset,
+			Format:          pkgInfo.Format,
+			FormatOverrides: pkgInfo.FormatOverrides,
+			Files:           pkgInfo.Files,
+			Link:            pkgInfo.Link,
+			Description:     pkgInfo.Description,
+			Replacements:    pkgInfo.Replacements,
 		}, nil
 	case pkgInfoTypeHTTP:
 		return &HTTPPackageInfo{
-			Name:                 pkgInfo.Name,
-			ArchiveType:          pkgInfo.ArchiveType,
-			ArchiveTypeOverrides: pkgInfo.ArchiveTypeOverrides,
-			URL:                  pkgInfo.URL,
-			Files:                pkgInfo.Files,
-			Link:                 pkgInfo.Link,
-			Description:          pkgInfo.Description,
-			Replacements:         pkgInfo.Replacements,
+			Name:            pkgInfo.Name,
+			Format:          pkgInfo.Format,
+			FormatOverrides: pkgInfo.FormatOverrides,
+			URL:             pkgInfo.URL,
+			Files:           pkgInfo.Files,
+			Link:            pkgInfo.Link,
+			Description:     pkgInfo.Description,
+			Replacements:    pkgInfo.Replacements,
 		}, nil
 	default:
 		return nil, logerr.WithFields(errInvalidType, logrus.Fields{ //nolint:wrapcheck
@@ -163,13 +163,13 @@ type File struct {
 
 func (file *File) RenderSrc(pkg *Package, pkgInfo PackageInfo) (string, error) {
 	return file.Src.Execute(map[string]interface{}{ //nolint:wrapcheck
-		"Version":     pkg.Version,
-		"GOOS":        runtime.GOOS,
-		"GOARCH":      runtime.GOARCH,
-		"OS":          replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":        replace(runtime.GOARCH, pkgInfo.GetReplacements()),
-		"ArchiveType": pkgInfo.GetArchiveType(),
-		"FileName":    file.Name,
+		"Version":  pkg.Version,
+		"GOOS":     runtime.GOOS,
+		"GOARCH":   runtime.GOARCH,
+		"OS":       replace(runtime.GOOS, pkgInfo.GetReplacements()),
+		"Arch":     replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Format":   pkgInfo.GetFormat(),
+		"FileName": file.Name,
 	})
 }
 

--- a/pkg/controller/download.go
+++ b/pkg/controller/download.go
@@ -56,7 +56,7 @@ func (ctrl *Controller) download(ctx context.Context, pkg *Package, pkgInfo Pack
 	}
 
 	defer body.Close()
-	return unarchive(body, assetName, pkgInfo.GetArchiveType(), dest)
+	return unarchive(body, assetName, pkgInfo.GetFormat(), dest)
 }
 
 var errGitHubTokenIsRequired = errors.New("GITHUB_TOKEN is required for the type `github_release`")

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -13,7 +13,7 @@ type GitHubReleasePackageInfo struct {
 	Format          string
 	Link            string
 	Description     string
-	Files           []*File `validate:"required,dive"`
+	Files           []*File `validate:"dive"`
 	Replacements    map[string]string
 	FormatOverrides []*FormatOverride
 
@@ -66,7 +66,14 @@ func (pkgInfo *GitHubReleasePackageInfo) GetPkgPath(rootDir string, pkg *Package
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetFiles() []*File {
-	return pkgInfo.Files
+	if len(pkgInfo.Files) != 0 {
+		return pkgInfo.Files
+	}
+	return []*File{
+		{
+			Name: pkgInfo.RepoName,
+		},
+	}
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (string, error) {

--- a/pkg/controller/github_release_package.go
+++ b/pkg/controller/github_release_package.go
@@ -9,13 +9,13 @@ import (
 )
 
 type GitHubReleasePackageInfo struct {
-	Name                 string
-	ArchiveType          string
-	Link                 string
-	Description          string
-	Files                []*File `validate:"required,dive"`
-	Replacements         map[string]string
-	ArchiveTypeOverrides []*ArchiveTypeOverride
+	Name            string
+	Format          string
+	Link            string
+	Description     string
+	Files           []*File `validate:"required,dive"`
+	Replacements    map[string]string
+	FormatOverrides []*FormatOverride
 
 	RepoOwner string
 	RepoName  string
@@ -44,13 +44,13 @@ func (pkgInfo *GitHubReleasePackageInfo) GetDescription() string {
 	return pkgInfo.Description
 }
 
-func (pkgInfo *GitHubReleasePackageInfo) GetArchiveType() string {
-	for _, arcTypeOverride := range pkgInfo.ArchiveTypeOverrides {
+func (pkgInfo *GitHubReleasePackageInfo) GetFormat() string {
+	for _, arcTypeOverride := range pkgInfo.FormatOverrides {
 		if arcTypeOverride.GOOS == runtime.GOOS {
-			return arcTypeOverride.ArchiveType
+			return arcTypeOverride.Format
 		}
 	}
-	return pkgInfo.ArchiveType
+	return pkgInfo.Format
 }
 
 func (pkgInfo *GitHubReleasePackageInfo) GetReplacements() map[string]string {
@@ -74,7 +74,7 @@ func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (s
 	if err != nil {
 		return "", fmt.Errorf("render the asset name: %w", err)
 	}
-	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+	if isUnarchived(pkgInfo.GetFormat(), assetName) {
 		return assetName, nil
 	}
 	if file.Src == nil {
@@ -89,11 +89,11 @@ func (pkgInfo *GitHubReleasePackageInfo) GetFileSrc(pkg *Package, file *File) (s
 
 func (pkgInfo *GitHubReleasePackageInfo) RenderAsset(pkg *Package) (string, error) {
 	return pkgInfo.Asset.Execute(map[string]interface{}{ //nolint:wrapcheck
-		"Version":     pkg.Version,
-		"GOOS":        runtime.GOOS,
-		"GOARCH":      runtime.GOARCH,
-		"OS":          replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":        replace(runtime.GOARCH, pkgInfo.GetReplacements()),
-		"ArchiveType": pkgInfo.GetArchiveType(),
+		"Version": pkg.Version,
+		"GOOS":    runtime.GOOS,
+		"GOARCH":  runtime.GOARCH,
+		"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
+		"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Format":  pkgInfo.GetFormat(),
 	})
 }

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -10,13 +10,13 @@ import (
 )
 
 type HTTPPackageInfo struct {
-	Name                 string `validate:"required"`
-	ArchiveType          string
-	Description          string
-	Link                 string
-	Files                []*File `validate:"required,dive"`
-	Replacements         map[string]string
-	ArchiveTypeOverrides []*ArchiveTypeOverride
+	Name            string `validate:"required"`
+	Format          string
+	Description     string
+	Link            string
+	Files           []*File `validate:"required,dive"`
+	Replacements    map[string]string
+	FormatOverrides []*FormatOverride
 
 	URL *text.Template `validate:"required"`
 }
@@ -37,13 +37,13 @@ func (pkgInfo *HTTPPackageInfo) GetDescription() string {
 	return pkgInfo.Description
 }
 
-func (pkgInfo *HTTPPackageInfo) GetArchiveType() string {
-	for _, arcTypeOverride := range pkgInfo.ArchiveTypeOverrides {
+func (pkgInfo *HTTPPackageInfo) GetFormat() string {
+	for _, arcTypeOverride := range pkgInfo.FormatOverrides {
 		if arcTypeOverride.GOOS == runtime.GOOS {
-			return arcTypeOverride.ArchiveType
+			return arcTypeOverride.Format
 		}
 	}
-	return pkgInfo.ArchiveType
+	return pkgInfo.Format
 }
 
 func (pkgInfo *HTTPPackageInfo) GetReplacements() map[string]string {
@@ -52,12 +52,12 @@ func (pkgInfo *HTTPPackageInfo) GetReplacements() map[string]string {
 
 func (pkgInfo *HTTPPackageInfo) GetPkgPath(rootDir string, pkg *Package) (string, error) {
 	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
-		"Version":     pkg.Version,
-		"GOOS":        runtime.GOOS,
-		"GOARCH":      runtime.GOARCH,
-		"OS":          replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":        replace(runtime.GOARCH, pkgInfo.GetReplacements()),
-		"ArchiveType": pkgInfo.GetArchiveType(),
+		"Version": pkg.Version,
+		"GOOS":    runtime.GOOS,
+		"GOARCH":  runtime.GOARCH,
+		"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
+		"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Format":  pkgInfo.GetFormat(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("render URL: %w", err)
@@ -78,7 +78,7 @@ func (pkgInfo *HTTPPackageInfo) GetFileSrc(pkg *Package, file *File) (string, er
 	if err != nil {
 		return "", fmt.Errorf("render the asset name: %w", err)
 	}
-	if isUnarchived(pkgInfo.GetArchiveType(), assetName) {
+	if isUnarchived(pkgInfo.GetFormat(), assetName) {
 		return assetName, nil
 	}
 	if file.Src == nil {
@@ -93,12 +93,12 @@ func (pkgInfo *HTTPPackageInfo) GetFileSrc(pkg *Package, file *File) (string, er
 
 func (pkgInfo *HTTPPackageInfo) RenderURL(pkg *Package) (string, error) {
 	uS, err := pkgInfo.URL.Execute(map[string]interface{}{
-		"Version":     pkg.Version,
-		"GOOS":        runtime.GOOS,
-		"GOARCH":      runtime.GOARCH,
-		"OS":          replace(runtime.GOOS, pkgInfo.GetReplacements()),
-		"Arch":        replace(runtime.GOARCH, pkgInfo.GetReplacements()),
-		"ArchiveType": pkgInfo.GetArchiveType(),
+		"Version": pkg.Version,
+		"GOOS":    runtime.GOOS,
+		"GOARCH":  runtime.GOARCH,
+		"OS":      replace(runtime.GOOS, pkgInfo.GetReplacements()),
+		"Arch":    replace(runtime.GOARCH, pkgInfo.GetReplacements()),
+		"Format":  pkgInfo.GetFormat(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("render URL: %w", err)

--- a/pkg/controller/unarchive.go
+++ b/pkg/controller/unarchive.go
@@ -38,7 +38,7 @@ func unarchive(body io.Reader, filename, typ, dest string) error { //nolint:cycl
 	arc, err := getUnarchiver(filename, typ)
 	if err != nil {
 		log.New().WithFields(logrus.Fields{
-			"archive_type":           typ,
+			"format":                 typ,
 			"filename":               filename,
 			"filepath.Ext(filename)": filepath.Ext(filename),
 		}).Error("get the unarchiver or decompressor")


### PR DESCRIPTION
Close #269

⚠️ BREAKING CHANGE; `archive_type` and `archive_type_overrides` are renamed

## Feature

Set the default `files` of `github_release` package.

The default value is

```yaml
files:
- name: <repo name>
```