### PR TITLE
feat: support changing package info per version

### DIFF
--- a/docs/registry_config.md
+++ b/docs/registry_config.md
@@ -34,6 +34,8 @@ packages:
 * `description`: The description about the package. This is used for `aqua g`
 * [replacements](#replacements-format_overrides): A map which is used to replace some Template Variables like `OS` and `Arch`
 * [format_overrides](#replacements-format_overrides): A list of the pair OS and the asset format
+* [version_constraint](#version_constraint-version_overrides): [expr](https://github.com/antonmedv/expr)'s expression. The evaluation result must be a boolean
+* [version_overrides](#version_constraint-version_overrides)
 
 ### `files`
 
@@ -99,3 +101,57 @@ Some fields are parsed with [Go's text/template](https://pkg.go.dev/text/templat
 * `Version`: Package `version`
 * `Format`: Package `format`
 * `FileName`: `files[].name`
+
+## `version_constraint`, `version_overrides`
+
+Some package attributes like `asset` and `files` may be different by it's version.
+For example, the asset structure of [golang-migrate](https://github.com/golang-migrate/migrate) was changed from v4.15.0.
+In that case, the attributes `version_constraint` and `version_overrides` are useful.
+
+e.g.
+
+```yaml
+- type: github_release
+  repo_owner: golang-migrate
+  repo_name: migrate
+  asset: 'migrate.{{.OS}}-{{.Arch}}.tar.gz'
+  description: Database migrations. CLI and Golang library
+  version_constraint: 'semver("> 4.14.1")'
+  version_overrides:
+  - version_constraint: 'semver("<= 4.14.1")'
+    files:
+    - name: migrate
+      src: 'migrate.{{.OS}}-{{.Arch}}'
+```
+
+`version_constraint` is [expr](https://github.com/antonmedv/expr)'s expression.
+The evaluation result must be a boolean.
+
+Currently, the following values and functions are accessible in the expression.
+
+* `version`: (type: `string`) The package version
+* `semver`: (type: `func(string) bool`) Tests if the package version satisfies all the constraints. [hashicorp/go-version](https://github.com/hashicorp/go-version) is used
+
+### version_overrides
+
+The list of version override.
+
+The following attributes are supported.
+
+* `version_constraint`
+* `files`
+* `format`
+* `format_overrides`
+* `replacements`
+* `asset`
+* `url`
+
+e.g.
+
+```yaml
+  version_overrides:
+  - version_constraint: 'semver("<= 4.14.1")'
+    files:
+    - name: migrate
+      src: 'migrate.{{.OS}}-{{.Arch}}'
+```

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/antonmedv/expr v1.9.0
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v39 v39.0.0
+	github.com/hashicorp/go-version v1.2.1
 	github.com/ktr0731/go-fuzzyfinder v0.5.0
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.22.0/go.mod h1:mAm5O/zik2RFmcpigNjg6nMotDL8ZXJaxKzgGVcSMFA=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -108,6 +109,8 @@ github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDa
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antonmedv/expr v1.9.0 h1:j4HI3NHEdgDnN9p6oI6Ndr0G5QryMY0FNxT4ONrFDGU=
+github.com/antonmedv/expr v1.9.0/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmHhwGEk8=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
@@ -154,6 +157,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -187,6 +191,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell v1.3.0 h1:r35w0JBADPZCVQijYebl6YMWWtHRqVEGt7kL2eBADRM=
+github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/gdamore/tcell/v2 v2.4.0 h1:W6dxJEmaxYvhICFoTY3WrLLEXsQ11SaFnKGVEXW57KM=
 github.com/gdamore/tcell/v2 v2.4.0/go.mod h1:cTTuF84Dlj/RqmaCIV5p4w8uG1zWdk0SF6oBpwHp4fU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -340,6 +346,7 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -412,6 +419,7 @@ github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -427,6 +435,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
@@ -478,6 +488,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -491,6 +502,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -504,6 +516,7 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -544,6 +557,7 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -775,6 +789,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/controller/exec.go
+++ b/pkg/controller/exec.go
@@ -97,6 +97,13 @@ func (ctrl *Controller) findExecFileFromPkg(registries map[string]*RegistryConte
 		logE.Warn("package isn't found")
 		return nil, nil
 	}
+
+	pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
+	if err != nil {
+		logE.Warn("version constraint is invalid")
+		return nil, nil
+	}
+
 	for _, file := range pkgInfo.GetFiles() {
 		if file.Name == exeName {
 			return pkgInfo, file

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -19,6 +19,11 @@ type HTTPPackageInfo struct {
 	URL *Template `validate:"required"`
 }
 
+func (pkgInfo *HTTPPackageInfo) SetVersion(v string) (PackageInfo, error) {
+	// TODO
+	return pkgInfo, nil
+}
+
 func (pkgInfo *HTTPPackageInfo) GetName() string {
 	return pkgInfo.Name
 }

--- a/pkg/controller/http_package.go
+++ b/pkg/controller/http_package.go
@@ -8,20 +8,78 @@ import (
 )
 
 type HTTPPackageInfo struct {
-	Name            string `validate:"required"`
-	Format          string
-	Description     string
-	Link            string
-	Files           []*File `validate:"required,dive"`
-	Replacements    map[string]string
-	FormatOverrides []*FormatOverride
+	Name               string `validate:"required"`
+	Format             string
+	Description        string
+	Link               string
+	Files              []*File `validate:"required,dive"`
+	Replacements       map[string]string
+	FormatOverrides    []*FormatOverride
+	VersionConstraints *VersionConstraints
+	VersionOverrides   []*HTTPVersionOverride
 
 	URL *Template `validate:"required"`
 }
 
 func (pkgInfo *HTTPPackageInfo) SetVersion(v string) (PackageInfo, error) {
-	// TODO
+	if pkgInfo.VersionConstraints == nil {
+		return pkgInfo, nil
+	}
+	a, err := pkgInfo.VersionConstraints.Check(v)
+	if err != nil {
+		return nil, err
+	}
+	if a {
+		return pkgInfo, nil
+	}
+	for _, vo := range pkgInfo.VersionOverrides {
+		a, err := vo.VersionConstraints.Check(v)
+		if err != nil {
+			return nil, err
+		}
+		if a {
+			return overrideHTTPPackageInfo(pkgInfo, vo), nil
+		}
+	}
 	return pkgInfo, nil
+}
+
+type HTTPVersionOverride struct {
+	VersionConstraints *VersionConstraints
+	URL                *Template `validate:"required"`
+	Files              []*File   `validate:"dive"`
+	Format             string
+	FormatOverrides    []*FormatOverride
+	Replacements       map[string]string
+}
+
+func overrideHTTPPackageInfo(base *HTTPPackageInfo, vo *HTTPVersionOverride) *HTTPPackageInfo {
+	p := &HTTPPackageInfo{
+		Name:            base.Name,
+		Format:          base.Format,
+		Link:            base.Link,
+		Description:     base.Description,
+		Files:           base.Files,
+		Replacements:    base.Replacements,
+		FormatOverrides: base.FormatOverrides,
+		URL:             base.URL,
+	}
+	if vo.URL != nil {
+		p.URL = vo.URL
+	}
+	if vo.Files != nil {
+		p.Files = vo.Files
+	}
+	if vo.Format != "" {
+		p.Format = vo.Format
+	}
+	if vo.FormatOverrides != nil {
+		p.FormatOverrides = vo.FormatOverrides
+	}
+	if vo.Replacements != nil {
+		p.Replacements = vo.Replacements
+	}
+	return p
 }
 
 func (pkgInfo *HTTPPackageInfo) GetName() string {

--- a/pkg/controller/install_packages.go
+++ b/pkg/controller/install_packages.go
@@ -26,6 +26,10 @@ func (ctrl *Controller) installPackages(ctx context.Context, cfg *Config, regist
 			failed = true
 			continue
 		}
+		pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
+		if err != nil {
+			return fmt.Errorf("evaluate version constraints: %w", err)
+		}
 		for _, file := range pkgInfo.GetFiles() {
 			if err := ctrl.createLink(binDir, file); err != nil {
 				logE.WithError(err).Error("create the symbolic link")
@@ -67,6 +71,12 @@ func (ctrl *Controller) installPackages(ctx context.Context, cfg *Config, regist
 				"registry":        pkg.Registry,
 			})
 			pkgInfo, err := getPkgInfoFromRegistries(registries, pkg)
+			if err != nil {
+				logE.WithError(err).Error("install the package")
+				handleFailure()
+				return
+			}
+			pkgInfo, err = pkgInfo.SetVersion(pkg.Version)
 			if err != nil {
 				logE.WithError(err).Error("install the package")
 				handleFailure()

--- a/pkg/controller/version_constraint.go
+++ b/pkg/controller/version_constraint.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+	"github.com/hashicorp/go-version"
+)
+
+type VersionConstraints struct {
+	raw  string
+	expr *vm.Program
+}
+
+func NewVersionConstraints(s string) *VersionConstraints {
+	return &VersionConstraints{
+		raw: s,
+	}
+}
+
+func (constraints *VersionConstraints) Compile() error {
+	if constraints.expr != nil {
+		return nil
+	}
+	a, err := expr.Compile(constraints.raw, expr.AsBool(), expr.Env(map[string]interface{}{
+		"semver": func(s string) bool {
+			return false
+		},
+	}))
+	if err != nil {
+		return fmt.Errorf("parse constraints: %w", err)
+	}
+	constraints.expr = a
+	return nil
+}
+
+func (constraints *VersionConstraints) Check(v string) (bool, error) {
+	if err := constraints.Compile(); err != nil {
+		return false, err
+	}
+	a, err := expr.Run(constraints.expr, map[string]interface{}{
+		"version": v,
+		"semver": func(s string) bool {
+			a, err := version.NewConstraint(s)
+			if err != nil {
+				panic(err)
+			}
+			ver, err := version.NewVersion(v)
+			if err != nil {
+				panic(err)
+			}
+			return a.Check(ver)
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("evaluate the expression: %w", err)
+	}
+	return a.(bool), nil
+}
+
+func (constraints *VersionConstraints) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw string
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	constraints.raw = raw
+	return nil
+}


### PR DESCRIPTION
Close #21

## `version_constraint`, `version_overrides`

Some package attributes like `asset` and `files` may be different by it's version.
For example, the asset structure of [golang-migrate](https://github.com/golang-migrate/migrate) was changed from v4.15.0.
In that case, the attributes `version_constraint` and `version_overrides` are useful.

e.g.

```yaml
- type: github_release
  repo_owner: golang-migrate
  repo_name: migrate
  asset: 'migrate.{{.OS}}-{{.Arch}}.tar.gz'
  description: Database migrations. CLI and Golang library
  version_constraint: 'semver("> 4.14.1")'
  version_overrides:
  - version_constraint: 'semver("<= 4.14.1")'
    files:
    - name: migrate
      src: 'migrate.{{.OS}}-{{.Arch}}'
```

`version_constraint` is [expr](https://github.com/antonmedv/expr)'s expression.
The evaluation result must be a boolean.

Currently, the following values and functions are accessible in the expression.

* `version`: (type: `string`) The package version
* `semver`: (type: `func(string) bool`) Tests if the package version satisfies all the constraints. [hashicorp/go-version](https://github.com/hashicorp/go-version) is used

### version_overrides

The list of version override.

The following attributes are supported.

* `version_constraint`
* `files`
* `format`
* `format_overrides`
* `replacements`
* `asset`
* `url`

e.g.

```yaml
  version_overrides:
  - version_constraint: 'semver("<= 4.14.1")'
    files:
    - name: migrate
      src: 'migrate.{{.OS}}-{{.Arch}}'
```