### PR TITLE
fix: when `-a` option is set, the error file isn't found is ignored

### DIFF
--- a/pkg/controller/install.go
+++ b/pkg/controller/install.go
@@ -31,11 +31,14 @@ func (ctrl *Controller) Install(ctx context.Context, param *Param) error {
 	}
 
 	cfgFilePath := ctrl.getConfigFilePath(wd, param.ConfigFilePath)
-	if cfgFilePath == "" {
-		return errConfigFileNotFound
-	}
-	if err := ctrl.install(ctx, rootBin, cfgFilePath, param); err != nil {
-		return err
+	if cfgFilePath != "" {
+		if err := ctrl.install(ctx, rootBin, cfgFilePath, param); err != nil {
+			return err
+		}
+	} else {
+		if !param.All {
+			return errConfigFileNotFound
+		}
 	}
 	return ctrl.installAll(ctx, rootBin, param)
 }


### PR DESCRIPTION
Close #331

When `aqua i` command's `-c` option isn't set, aqua finds the configuration file from the current directory to the root directory.
When `aqua i` command's `-a` option is set, `aqua i` should not fail even if the configuration file isn't found.