### PR TITLE
feat: generate code with new syntax

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -17,7 +17,7 @@ import (
 type Package struct {
 	Name     string `validate:"required"`
 	Registry string `validate:"required"`
-	Version  string `validate:"required"`
+	Version  string `validate:"required" yaml:",omitempty"`
 }
 
 func (pkg *Package) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/controller/generate.go
+++ b/pkg/controller/generate.go
@@ -154,6 +154,7 @@ func (ctrl *Controller) getOutputtedPkg(ctx context.Context, pkg *FindingPackage
 	outputPkg := &Package{
 		Name:     pkg.PackageInfo.GetName(),
 		Registry: pkg.RegistryName,
+		Version:  "[SET PACKAGE VERSION]",
 	}
 	if pkg.PackageInfo.GetType() != pkgInfoTypeGitHubRelease {
 		return outputPkg, nil
@@ -173,6 +174,11 @@ func (ctrl *Controller) getOutputtedPkg(ctx context.Context, pkg *FindingPackage
 		}).Warn("get the latest release")
 		return outputPkg, nil
 	}
-	outputPkg.Version = release.GetTagName()
+	if pkg.PackageInfo.GetName() == p.RepoOwner+"/"+p.RepoName {
+		outputPkg.Name += "@" + release.GetTagName()
+		outputPkg.Version = ""
+	} else {
+		outputPkg.Version = release.GetTagName()
+	}
 	return outputPkg, nil
 }


### PR DESCRIPTION
Follow up #334

e.g.

```console
$ echo standard,kubernetes/kubectl | aqua g -f -
- name: kubernetes/kubectl
  registry: standard
  version: '[SET PACKAGE VERSION]'
```

```console
$ echo standard,ahmetb/kubectl-tree | aqua g -f -
- name: ahmetb/kubectl-tree@v0.4.1
  registry: standard
```