### PR TITLE
fix: generate `github_content` package's configuration with new syntax

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -22,6 +22,7 @@ jobs:
     - run: echo "AQUA_GLOBAL_CONFIG=$PWD/aqua-global.yaml:$PWD/aqua-global-2.yaml" >> $GITHUB_ENV
     - run: echo "standard,kubernetes-sigs/kind" | aqua g -f -
     - run: echo "standard,x-motemen/ghq" | aqua g -f -
+    - run: echo "inline,suzuki-shunsuke/aqua-installer" | aqua g -f -
 
     - run: aqua list
     - run: aqua i -l -a


### PR DESCRIPTION
Follow up #342

Fix the generation of `github_content` type's package configuration by `aqua g` command.

* Get the latest version
* Use the new syntax

AS IS

```console
$ echo "standard,suzuki-shunsuke/aqua-installer" | aqua g -f -
- name: suzuki-shunsuke/aqua-installer
  version: '[SET PACKAGE VERSION]'
```

TO BE

```console
$ echo "standard,suzuki-shunsuke/aqua-installer" | aqua g -f -
- name: suzuki-shunsuke/aqua-installer@v0.1.3
```