### PR TITLE
fix: failed to create a symbolic link to aqua-proxy: file exists

### DIFF
--- a/pkg/controller/install_packages.go
+++ b/pkg/controller/install_packages.go
@@ -31,7 +31,7 @@ func (ctrl *Controller) installPackages(ctx context.Context, cfg *Config, regist
 			return fmt.Errorf("evaluate version constraints: %w", err)
 		}
 		for _, file := range pkgInfo.GetFiles() {
-			if err := ctrl.createLink(binDir, file); err != nil {
+			if err := ctrl.createLink(filepath.Join(binDir, file.Name), proxyName); err != nil {
 				logerr.WithError(logE, err).Error("create the symbolic link")
 				failed = true
 				continue
@@ -202,9 +202,7 @@ func allowOwnerExec(mode os.FileMode) os.FileMode {
 	return mode | OwnerExecutable
 }
 
-func (ctrl *Controller) createLink(binDir string, file *File) error {
-	linkPath := filepath.Join(binDir, file.Name)
-	linkDest := proxyName
+func (ctrl *Controller) createLink(linkPath, linkDest string) error {
 	if fileInfo, err := os.Lstat(linkPath); err == nil {
 		switch mode := fileInfo.Mode(); {
 		case mode.IsDir():

--- a/pkg/controller/install_proxy.go
+++ b/pkg/controller/install_proxy.go
@@ -62,9 +62,6 @@ func (ctrl *Controller) installProxy(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get a relative path: %w", err)
 	}
-	if err := os.Symlink(a, filepath.Join(ctrl.RootDir, "bin", proxyName)); err != nil {
-		return fmt.Errorf("create a symbolic link: %w", err)
-	}
 
-	return nil
+	return ctrl.createLink(filepath.Join(ctrl.RootDir, "bin", proxyName), a)
 }


### PR DESCRIPTION
Close #395