### PR TITLE
fix: fix `github_content` package's install path

### DIFF
--- a/pkg/controller/package_info.go
+++ b/pkg/controller/package_info.go
@@ -71,7 +71,7 @@ func (pkgInfo *MergedPackageInfo) GetFileSrc(pkg *Package, file *File) (string, 
 		return "", fmt.Errorf("render the asset name: %w", err)
 	}
 	if isUnarchived(pkgInfo.GetFormat(), assetName) {
-		return assetName, nil
+		return filepath.Base(assetName), nil
 	}
 	if file.Src == nil {
 		return file.Name, nil

--- a/pkg/controller/unarchive.go
+++ b/pkg/controller/unarchive.go
@@ -21,6 +21,7 @@ func isUnarchived(archiveType, assetName string) bool {
 }
 
 func getUnarchiver(filename, typ, dest string) (Unarchiver, error) {
+	filename = filepath.Base(filename)
 	if isUnarchived(typ, filename) {
 		return &rawUnarchiver{
 			dest: filepath.Join(dest, filename),


### PR DESCRIPTION
Close #408

## Breaking Change

If you have already installed `github_content` packages, you may have to reinstall them.

```console
$ dgoss --help
WARN[0000] check file_src is correct                     aqua_version= error="exe_path isn't found: stat ~/.aqua/pkgs/github_content/github.com/aelsabbahy/goss/v0.3.16/extras/dgoss/dgoss/dgoss: no such file or directory" file_name=dgoss package_name=aelsabbahy/goss/dgoss package_version=v0.3.16 program=aqua registry=standard
```

### How to fix

Remove `github_content` packages at once.

e.g.

```
$ rm -R ~/.aqua/pkgs/github_content
```